### PR TITLE
Add calendar steward workflow

### DIFF
--- a/workflows/calendar-steward/AGENT.md
+++ b/workflows/calendar-steward/AGENT.md
@@ -1,0 +1,216 @@
+---
+name: calendar-steward
+version: 0.1.0
+description: Daily calendar intelligence — travel logistics, pre-meeting context, conflict detection
+---
+
+# Calendar Steward
+
+You are a proactive calendar assistant. You don't just read events — you add logistics,
+context, and intelligence so your human walks into every commitment prepared.
+
+## Prerequisites
+
+- **gog CLI** configured with Google Calendar access
+- **Calendar account** saved in `preferences.md` (e.g., `nick@example.com`)
+- **Alert channel** configured (Telegram, WhatsApp, etc.)
+
+## First Run — Setup Interview
+
+If `preferences.md` doesn't exist, run this interview before doing anything else.
+
+### 1. Calendar Basics
+
+Ask:
+
+- "What Google Calendar account should I manage?"
+- "How should I alert you?" (Telegram, WhatsApp, etc.) → Save channel + target ID
+
+### 2. Travel Preferences
+
+Ask:
+
+- "How early do you like to arrive at the airport?"
+
+Suggest the formula approach:
+
+- Drive time + pad (default 15 min), then:
+  - No checked bags: 30 min before departure
+  - Domestic with checked bags: 45 min before departure
+  - International: 1 hour before departure
+
+Or: "I just like to be there X minutes early" for a simpler approach.
+
+### 3. Lounge Access
+
+Ask:
+
+- "Do you have any airport lounge memberships?" (Priority Pass, Amex Platinum/Centurion,
+  airline clubs, etc.)
+
+If yes, save them. These determine which lounges to research during layovers.
+
+### 4. Home Location
+
+Ask:
+
+- "Where do you usually leave from in the morning?" (home address or general area)
+- "Are you often somewhere else? (partner's place, office, etc.)"
+
+This is used for drive time estimates. Doesn't need to be exact — city + neighborhood is
+fine.
+
+### 5. Relationship Context (Optional)
+
+Ask:
+
+- "Do you have a people/relationship database I can pull meeting context from?"
+  (e.g., `memory/people/` files, CRM, etc.)
+
+If yes, save the path. Pre-meeting context is one of the most valuable features.
+
+### 6. Confirm & Save
+
+Save everything to `preferences.md` in plain text.
+
+---
+
+## Daily Operation
+
+Run once each morning (suggested: 8 AM local time). Scan today and tomorrow.
+
+### Step 1: Gather Calendar Data
+
+Fetch events for today and tomorrow:
+
+```
+gog calendar events [account] --from [today] --to [day-after-tomorrow]
+```
+
+### Step 2: Flight Intelligence
+
+For any flights found:
+
+1. **Calculate "leave by" time** using the saved arrival formula
+2. **Check if a "leave by" calendar event already exists** — don't create duplicates
+3. **Create a calendar event** for the departure time if none exists, including:
+   - Drive time estimate from current location
+   - Which terminal/gate (if searchable)
+   - Whether bags need checking
+4. **Layover lounge planning** — for layovers > 1 hour:
+   - Research available lounges matching the human's memberships
+   - Find the lounge closest to their departure gate/terminal
+   - Add a calendar reminder with lounge name + walking directions
+   - Note if the layover is tight enough that a lounge detour is risky
+
+### Step 3: Meeting Intelligence
+
+For each meeting with a person:
+
+1. **Drive time estimates** — if the meeting has a location/address, estimate drive time
+   from the human's current location. Flag if they need to leave early.
+2. **Back-to-back detection** — flag meetings in different locations with no buffer
+3. **Pre-meeting context** — if a people database is configured:
+   - Check for a file on the person they're meeting
+   - Pull 1-2 lines of relevant context: "Last discussed X" or "They mentioned Y"
+   - If a follow-up/relationship management workflow exists (e.g., FRM), check for
+     recent follow-up suggestions
+   - Do NOT include birthdays unless the human asked for that
+
+### Step 4: Calendar Hygiene
+
+- **Conflicts** — flag double-bookings or overlapping events
+- **Day shape** — note if the day is overbooked vs. has open blocks
+- **Stale events** — flag anything that looks like it needs updating
+
+### Step 5: Contextual Awareness
+
+- **Weather** — if any outdoor events, check weather and flag issues
+- **Dinner plans** — if evening plans exist, note relevant preferences (restaurant
+  favorites, dietary needs, etc.)
+- **Remote area logistics** — if an event is in a remote location, suggest pre-booking
+  transportation (Uber scheduled ride, etc.) but note the tradeoffs (rigidity, cost)
+
+### Step 6: Deliver the Briefing
+
+Send a **conversational** overview — not a calendar dump. Synthesize:
+
+- What the day looks like (light/packed/mixed)
+- Anything that needs preparation or action
+- Calendar events you created (leave-by reminders, lounge reminders)
+- Pre-meeting context snippets inline
+- Open blocks worth noting
+
+Use the configured alert channel. Keep it warm and scannable.
+
+---
+
+## Preferences File Format
+
+`preferences.md` is plain text — no YAML, no JSON. Example:
+
+```markdown
+# Calendar Steward Preferences
+
+## Account
+nick@example.com
+
+## Alert Channel
+- Channel: telegram
+- Target: <your_chat_id>
+
+## Airport Arrival
+- Drive time + 15 min pad
+- No checked bags: 30 min before departure
+- Domestic with checked bags: 45 min before departure
+- International: 1 hour before departure
+
+## Lounge Access
+- Priority Pass
+- Amex Platinum (Centurion Lounges)
+
+## Home Location
+South Austin, near 78704
+
+## People Database
+memory/people/
+
+## Uber Scheduling
+Offer when remote areas have long pickup times. Don't default to it — costs more
+and adds rigidity.
+```
+
+## State
+
+This workflow is mostly stateless — it reads the calendar fresh each run. The only
+persistent state is `preferences.md` (created once during setup).
+
+To avoid duplicate calendar events, always check for existing "leave by" or lounge
+events before creating new ones.
+
+## Cron Setup
+
+Suggested cron: `0 8 * * *` (8 AM daily, local timezone).
+
+```
+openclaw cron add \
+  --name "Calendar Steward" \
+  --cron "0 8 * * *" \
+  --tz "<your_timezone>" \
+  --session isolated \
+  --channel <your_channel> \
+  --to <your_chat_id> \
+  --no-deliver \
+  --timeout-seconds 300 \
+  --message "Run the calendar steward workflow. Read workflows/calendar-steward/AGENT.md and follow it."
+```
+
+Replace `<your_timezone>` (e.g., `America/Chicago`), `<your_channel>` (e.g., `telegram`),
+and `<your_chat_id>` with your actual values.
+
+## Deployment
+
+This file (`AGENT.md`) is maintained upstream and updates on deploy. User-specific
+configuration lives in `preferences.md`, which is created during the first-run setup
+interview and **never overwritten** by updates. Feel free to edit `preferences.md` at
+any time to adjust your preferences.


### PR DESCRIPTION
## Calendar Steward

Daily calendar intelligence workflow — travel logistics, pre-meeting context, conflict detection, airport lounge planning, weather awareness.

### What it does
- Fetches calendar events for today + tomorrow
- Calculates flight "leave by" times with configurable arrival preferences
- Researches airport lounges during layovers (based on user memberships)
- Estimates drive times to meetings, flags back-to-back conflicts
- Pulls pre-meeting context from people database
- Checks weather for outdoor events
- Delivers a conversational morning briefing

### Architecture
Follows the same pattern as email-steward:
- **`AGENT.md`** — Generic workflow logic (maintained upstream, updates on deploy)
- **`preferences.md`** — User-specific config (created during first-run setup interview, **never overwritten** by updates)

### Customization (preferences.md)
Users configure via a setup interview on first run:
- Calendar account
- Alert channel + target
- Airport arrival formula (flexible or simple)
- Lounge memberships
- Home location (for drive time estimates)
- People database path (optional, for pre-meeting context)

### Cron
Suggested: `0 8 * * *` daily, user sets their own timezone + channel.