### PR TITLE
Add openclaw-debugger agent — two-tier incident response

### DIFF
--- a/.claude/agents/openclaw-debugger.md
+++ b/.claude/agents/openclaw-debugger.md
@@ -65,7 +65,7 @@ seconds later.
 - Kill hung processes (log PID and reason before killing)
 - Clear stale lock files, temp files, and old logs
 - Fix file permissions to match machine-setup.md spec (700 for ~/.openclaw)
-- Reinstall software via Homebrew (uv, restic, pnpm)
+- Reinstall software: uv and restic via Homebrew, pnpm via `npm install -g pnpm`
 - Re-enable or reload launchd agents (gateway, backup, backup-verify)
 - Correct shell PATH issues for non-interactive sessions
 - Modify `~/.openclaw/openclaw.json` to fix model IDs, delivery modes, and agent

--- a/devops/health-check.md
+++ b/devops/health-check.md
@@ -204,11 +204,12 @@ findings, and note "DEBUGGER LAUNCH FAILED" so the admin knows the escalation pa
 itself is broken. If the debugger started successfully, log the escalation to
 `~/.openclaw/health-check.log` and stop.
 
-**When to escalate vs notify the admin directly.** The simple heuristic: if you
-attempted a fix and the issue persists, escalate — the debugger has wider authority and
-deeper reasoning. If the issue is outside your authority to even attempt (hardware
-failures, expired API keys, network problems requiring credentials), notify the admin
-directly. Escalation invokes Opus, so reserve it for issues that require reasoning about
+**When to escalate vs notify the admin directly.** Escalate when: you attempted a fix
+and the issue persists, OR the problem is config drift, cron failure, backup issue,
+software missing, or launchd agents not loaded — things the debugger can repair even if
+you can't. Notify the admin directly when the problem is fundamentally beyond
+programmatic repair: hardware failures, expired API keys, network issues requiring human
+credentials. Escalation invokes Opus, so reserve it for issues requiring reasoning about
 config, state, or multi-step repair.
 
 Escalation is free — write the debug request and hand off without budget concern.


### PR DESCRIPTION
## Summary

- **New agent**: `.claude/agents/openclaw-debugger.md` — Opus-powered debugger invoked when the health sentinel (Haiku) finds problems it can't fix
- **Updated**: `devops/health-check.md` — added escalation section with failure detection, stale-request handling, and active-escalation guards
- Replaced negative "Don't" boundary lists with positive-framed "Boundaries" sections in both files

## Design

The health sentinel runs cheap hourly checks with Haiku. When it encounters problems beyond its authority (config drift, deep gateway failures, backup issues), it writes context to `~/.openclaw/debug-request.md` and starts the debugger agent. The debugger has wider repair authority: config modification, backup restoration, software reinstall.

Safety mechanisms:
- Exit code check on debugger launch with fallback to direct admin notification
- Stale debug-request.md detection (>2h = previous debugger failed)
- Active escalation guard (sentinel skips remediation while debugger runs)
- Clear boundary definitions for both tiers

## Test plan

- [ ] Verify agent file format matches ai-coding-config conventions (frontmatter, prettier-ignore, quoted description)
- [ ] Review health-check.md escalation section reads naturally as prose (not over-prescribed steps)
- [ ] Confirm boundary definitions are consistent between both files
- [ ] Validate `claude --agent openclaw-debugger` invocation syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)