### PR TITLE
Fix 'on boot' wording in embeddings guide

### DIFF
--- a/devops/embeddings-guide.md
+++ b/devops/embeddings-guide.md
@@ -158,7 +158,7 @@ brew install ollama
 # Pull the embedding model
 ollama pull bge-m3
 
-# Enable auto-start on boot
+# Enable auto-start on login
 brew services start ollama
 
 # Verify


### PR DESCRIPTION
## Summary

- Fix incorrect "on boot" comment in Ollama setup section — `brew services start` (without sudo) creates a user LaunchAgent that starts on **login**, not boot
- The explanatory paragraph below already had the correct wording; this aligns the code comment

Addresses review feedback from PR #32.

## Test plan

- [x] Verified the fix matches macOS LaunchAgent behavior
- [x] Confirmed line 169 explanatory text already says "on login"

🤖 Generated with [Claude Code](https://claude.com/claude-code)