### PR TITLE
Fix firstname-unknown.md collision disambiguation

### DIFF
--- a/skills/librarian/SKILL.md
+++ b/skills/librarian/SKILL.md
@@ -216,7 +216,9 @@ As part of each maintenance loop:
 
 - All filenames: **kebab-case** (`alex-chen.md`, not `Alex Chen.md`)
 - People files: `firstname-lastname.md`; if last name unknown, use
-  `firstname-unknown.md` as a placeholder (never bare `firstname.md`)
+  `firstname-unknown.md` as a placeholder (never bare `firstname.md`); if multiple
+  people share a first name with unknown last names, add a brief descriptor:
+  `john-unknown-contractor.md`, `john-unknown-neighbor.md`
 - Date files: `YYYY-MM-DD.md`
 - Decision files: `YYYY-MM-DD-topic.md`
 - All files are markdown


### PR DESCRIPTION
## Summary

- Adds documentation for disambiguating `firstname-unknown.md` files when multiple people share a first name with unknown last names (e.g., `john-unknown-contractor.md`)

## Addresses

Cursor bot feedback on PR #46 — low-severity collision risk when two people share a first name and both have unknown last names. The old convention didn't document how to handle this. Now it does.

## Test plan

- [ ] Verify `skills/librarian/SKILL.md` lines 218-221 read correctly
- [ ] Confirm the descriptor pattern is clear and actionable for agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)