### PR TITLE
Fix stale processed.md refs in platform files (review sweep #49)

### DIFF
--- a/workflows/contact-steward/platforms/imessage.md
+++ b/workflows/contact-steward/platforms/imessage.md
@@ -198,7 +198,7 @@ iMessage gets more spam than WhatsApp. Common patterns to skip:
 1. `imsg chats --limit 100` — get conversations (use a larger limit to reach threads up
    to 90 days back)
 2. Filter to phone numbers and emails (skip short codes, RBM agents)
-3. For each, check `processed.md` — skip if already processed with no new messages
+3. For each, check `processed.db` — skip if already processed with no new messages
 4. `imsg history --chat-id <id> --limit 15` — read recent messages
 5. Check if your human sent any messages (`[sent]`) — if not, skip
 6. Cross-reference (if WhatsApp is configured): `wacli contacts search "<number>"` to

--- a/workflows/contact-steward/platforms/quo.md
+++ b/workflows/contact-steward/platforms/quo.md
@@ -117,7 +117,7 @@ does the "is this a known contact?" check for you.
 
 1. `quo conversations --unknown --limit 50` — get conversations with unknown numbers
    (larger limit to reach up to 90 days back)
-2. For each, check `processed.md` — skip if already processed with no new activity
+2. For each, check `processed.db` — skip if already processed with no new activity
 3. `quo gather <phone> --since <90-days-ago-ISO>` — pull all messages, calls,
    transcripts (explicit `--since` required — default is 30 days which misses older
    conversations)

--- a/workflows/contact-steward/platforms/whatsapp.md
+++ b/workflows/contact-steward/platforms/whatsapp.md
@@ -165,7 +165,7 @@ notifications, or suggesting contact additions), use this priority:
 
 1. Use `business_name` as the display name
 2. Flag as business -> skip per workflow rules
-3. Log in `processed.md` with any human contact name found in conversation
+3. Log in `processed.db` with any human contact name found in conversation
 
 ### "More Complete" Check
 
@@ -207,7 +207,7 @@ This is the correct action for unknown contacts — set their alias to the resol
 1. `wacli chats list --limit 200 --json` — get conversations (use a large limit to reach
    threads up to 90 days back)
 2. Filter to `Kind: "dm"` or `Kind: "unknown"` (LID contacts), skip groups
-3. For each, check `processed.md` — skip if already processed with no new messages
+3. For each, check `processed.db` — skip if already processed with no new messages
 4. `wacli messages list --chat "<JID>" --limit 20 --json` — read recent messages
    (remember: messages are under `data.messages`)
 5. Check if your human replied (`FromMe: true`) — if not, skip


### PR DESCRIPTION
## Summary

- Updated 4 stale `processed.md` references to `processed.db` in platform scanner flows (whatsapp.md, imessage.md, quo.md)
- PR #49 migrated tracking state from markdown to SQLite but the platform-specific files weren't updated

Caught by Cursor Bugbot on PR #49.

## Test plan

- [ ] Verify no remaining `processed.md` references in platform files
- [ ] Confirm AGENT.md already references `processed.db` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)