### PR TITLE
Fix partial sync version marker and basename matching

### DIFF
--- a/skills/openclaw/openclaw
+++ b/skills/openclaw/openclaw
@@ -119,6 +119,10 @@ cmd_sync() {
     if $only_skills || $only_templates || $only_workflows; then
         sync_all=false
     fi
+    # If all three partial flags are set, it's functionally a full sync
+    if $only_skills && $only_templates && $only_workflows; then
+        sync_all=true
+    fi
 
     # Sync templates
     if $sync_all || $only_templates; then

--- a/skills/openclaw/openclaw
+++ b/skills/openclaw/openclaw
@@ -84,8 +84,9 @@ cmd_status() {
 is_user_owned() {
     local file="$1"
     local base=$(basename "$file")
+    # Only match user-owned files at the root level of the workflow directory
     for uf in $USER_OWNED_FILES; do
-        [ "$base" = "$uf" ] && return 0
+        [ "$file" = "$uf" ] && return 0
     done
     for ud in $USER_OWNED_DIRS; do
         # Match paths starting with the dir (logs/foo.md) or containing it (/logs/)
@@ -182,8 +183,8 @@ cmd_sync() {
         echo "✓ Everything up to date"
     fi
 
-    # Update installed version
-    if ! $dry_run && [ -f "$OPENCLAW_REPO/VERSION" ]; then
+    # Only update installed version on full sync (partial sync leaves other categories stale)
+    if ! $dry_run && $sync_all && [ -f "$OPENCLAW_REPO/VERSION" ]; then
         cp "$OPENCLAW_REPO/VERSION" "$OPENCLAW_CACHE/installed-version"
     fi
 }


### PR DESCRIPTION
## Summary

Follow-up fixes from bot review of PR #61:

- **Partial sync version marker** (cursor[bot]): `installed-version` was updated unconditionally, even during `--skills`/`--templates`/`--workflows` partial syncs. This caused `cmd_status` to report "Up to date" when unsynced categories were still stale. Fix: gate on `$sync_all`.
- **Basename matching** (cursor[bot]): `is_user_owned` matched on `basename`, so any upstream file in a subdirectory sharing a name with a user-owned file (e.g. `platforms/preferences.md`) would be silently skipped during sync. Fix: match full relative path so only root-level user files are protected.

## Test plan

- [ ] `openclaw sync --skills` should NOT update `installed-version`
- [ ] `openclaw sync` (no flags) should still update `installed-version`
- [ ] Upstream file `platforms/preferences.md` (if it existed) should sync, not be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)