### PR TITLE
Fix missing PIDFile in forking systemd VNC unit

### DIFF
--- a/devops/remote-desktop-setup.md
+++ b/devops/remote-desktop-setup.md
@@ -219,6 +219,7 @@ After=network.target
 
 [Service]
 Type=forking
+PIDFile=%h/.vnc/%H:1.pid
 ExecStartPre=-/usr/bin/vncserver -kill :1
 ExecStart=/usr/bin/vncserver :1 -geometry 1280x800 -depth 24 -localhost no
 ExecStop=/usr/bin/vncserver -kill :1


### PR DESCRIPTION
## Summary

Adds `PIDFile=%h/.vnc/%H:1.pid` to the VNC systemd service unit in the remote desktop setup guide.

`Type=forking` without `PIDFile` means systemd can't reliably track the main VNC daemon process after fork — crash restart (`Restart=on-failure`) may not work correctly.

The `%h/.vnc/%H:1.pid` pattern matches the standard TigerVNC PID file location.

Fixes cursor[bot] review comment on #52.

🤖 Generated with Hex