### PR TITLE
docs(model-aliases): heart-centered EQ-based model selection overhaul

### DIFF
--- a/knowledge/model-aliases.md
+++ b/knowledge/model-aliases.md
@@ -5,52 +5,120 @@ AGENT.md files, and skill prompts should reference aliases — never hardcoded m
 
 ## Alias Table
 
-| Alias           | Model ID                                   | Purpose                             |
-| --------------- | ------------------------------------------ | ----------------------------------- |
-| `cheap`         | `openrouter/free`                          | Shell scripts, trivial tasks        |
-| `simple`        | `openrouter/anthropic/claude-haiku-4.5`    | Sentinels, healthchecks, triage     |
-| `work`          | `openrouter/openai/gpt-5.4`                | Stewards, inbox, browser work       |
-| `chat`          | `openrouter/anthropic/claude-sonnet-4.6`   | Main session (agent's voice)        |
-| `chat-fallback` | `openrouter/google/gemini-3.1-pro-preview` | Chat backup                         |
-| `think`         | `openrouter/anthropic/claude-opus-4.6`     | Deep reasoning, nightly reflection  |
-| `verify`        | `openrouter/qwen/qwen3.6-plus:free`        | Cross-check, different model family |
-| `grok`          | `openrouter/x-ai/grok-4.1-fast`            | Web-grounded queries                |
-| `local`         | `lmstudio/google/gemma-3-4b`               | Local inference                     |
+| Alias           | Model ID                                   | Purpose                            |
+| --------------- | ------------------------------------------ | ---------------------------------- |
+| `cheap`         | `openrouter/stepfun/step-3.5-flash`        | Shell scripts, trivial tasks       |
+| `simple`        | `openrouter/minimax/minimax-m2.7`          | Sentinels, healthchecks, triage    |
+| `work`          | `openrouter/xiaomi/mimo-v2-pro`            | Stewards, inbox, browser work      |
+| `chat-fallback` | `openrouter/google/gemini-3.1-pro-preview` | Backup when default is down        |
+| `think`         | `openrouter/anthropic/claude-opus-4.6`     | Deep reasoning, nightly reflection |
+| `verify`        | `openrouter/x-ai/grok-4.20`                | Cross-check, web-grounded          |
 
-## Default Model Chain
+## Default Model
 
-- **Primary:** `chat` (openrouter/anthropic/claude-sonnet-4.6)
+The default model is not an alias — it's the primary model used for conversations and
+any task that doesn't specify an alias. Set via `agents.defaults.model.primary`.
+
+### Subscription machines (preferred)
+
+Machines with a ChatGPT subscription ($200/mo) use GPT-5.4 via the codex provider. This
+is effectively unlimited and has the highest EQ score (73.2) of any model tested.
+Requires an `openai-codex` auth profile with OAuth mode.
+
+- **Primary:** `openai-codex/gpt-5.4`
 - **Fallback 1:** `chat-fallback` (openrouter/google/gemini-3.1-pro-preview)
-- **Fallback 2:** `work` (openrouter/openai/gpt-5.4)
-- **Heartbeat:** `simple` (openrouter/anthropic/claude-haiku-4.5)
+- **Fallback 2:** `work` (openrouter/xiaomi/mimo-v2-pro)
+- **Heartbeat:** `openai-codex/gpt-5.4`
+
+### OpenRouter-only machines
+
+Machines without a subscription fall back to Sonnet as the default.
+
+- **Primary:** `openrouter/anthropic/claude-sonnet-4-6`
+- **Fallback 1:** `chat-fallback` (openrouter/google/gemini-3.1-pro-preview)
+- **Fallback 2:** `work` (openrouter/xiaomi/mimo-v2-pro)
+- **Heartbeat:** `openrouter/anthropic/claude-haiku-4.5`
+
+## Cost Ladder
+
+```
+cheap ($0.15) → simple ($0.53) → work ($1.50) → verify ($3.00) → chat-fallback ($4.50) → think ($10.00)
+```
+
+On subscription machines, the default model (GPT-5.4) is effectively free — only the
+aliases above incur per-token cost.
+
+## EQ Benchmarks (EQ-Bench v3, 0-100)
+
+| Alias           | EQ Score | Notable Traits                              |
+| --------------- | -------- | ------------------------------------------- |
+| `default`       | 73.2     | Highest EQ, best insight (15.8) — GPT-5.4   |
+| `cheap`         | 69.25    | Best EQ-per-dollar in the field             |
+| `simple`        | 68.75    | Best theory of mind (15.1), subtext (16.3)  |
+| `work`          | 70.55    | Highest humanlike (15.1), analytical (18.1) |
+| `chat-fallback` | 68.95    | Balanced, fast (127 tok/s)                  |
+| `think`         | 71.85    | Highest empathy (14.9), warmth (13.6)       |
+| `verify`        | 68.55    | Web-grounded, fastest model (271 tok/s)     |
+
+Source: https://heartcentered.ai/model-benchmarks/
 
 ## Design Principles
 
 - **No direct `anthropic/*` calls** — always via `openrouter/anthropic/*`
 - **Alias, not model ID** — cron jobs use alias names so the underlying model can be
   swapped fleet-wide in one config edit
-- **Different families for spend visibility** — Anthropic spend = conversations, OpenAI
-  = automation, Google = fallback. Easy to split on OpenRouter dashboard.
-- **`cheap` → `simple` → `work` → `chat` → `think`** = quality/cost spectrum. Name
-  reflects the job's needs, not the model's brand.
+- **Every alias = unique model** — distinct line items in OpenRouter dashboard for spend
+  visibility by job type
+- **`cheap` → `simple` → `work` → `think`** = quality/cost spectrum. Name reflects the
+  job's needs, not the model's brand.
+- **Default is not an alias** — it's the primary model set in config. Subscription
+  machines use GPT-5.4 (unlimited); others use Sonnet.
 - **`verify`** = always a different model family for genuine cross-validation
+- **Heart-centered selection** — models chosen for emotional intelligence alongside
+  capability, not just IQ and cost. EQ-Bench v3 scores inform every alias choice.
 
 ## Applying to a New Machine
 
-Set in `openclaw.json` under `agents.defaults.models`, or use the CLI:
+### Aliases (all machines)
 
 ```bash
-openclaw models aliases add cheap openrouter/free
-openclaw models aliases add simple openrouter/anthropic/claude-haiku-4.5
-openclaw models aliases add work openrouter/openai/gpt-5.4
-openclaw models aliases add chat openrouter/anthropic/claude-sonnet-4.6
+openclaw models aliases add cheap openrouter/stepfun/step-3.5-flash
+openclaw models aliases add simple openrouter/minimax/minimax-m2.7
+openclaw models aliases add work openrouter/xiaomi/mimo-v2-pro
 openclaw models aliases add chat-fallback openrouter/google/gemini-3.1-pro-preview
 openclaw models aliases add think openrouter/anthropic/claude-opus-4.6
-openclaw models aliases add verify openrouter/qwen/qwen3.6-plus:free
+openclaw models aliases add verify openrouter/x-ai/grok-4.20
+```
+
+### Default model — Subscription (preferred)
+
+```bash
+openclaw auth add openai-codex --mode oauth
+openclaw config set agents.defaults.model.primary "openai-codex/gpt-5.4"
+openclaw config set agents.defaults.model.fallbacks '["openrouter/google/gemini-3.1-pro-preview", "openrouter/xiaomi/mimo-v2-pro"]'
+openclaw config set agents.defaults.heartbeat.model "openai-codex/gpt-5.4"
+```
+
+### Default model — OpenRouter only
+
+```bash
+openclaw config set agents.defaults.model.primary "openrouter/anthropic/claude-sonnet-4-6"
+openclaw config set agents.defaults.model.fallbacks '["openrouter/google/gemini-3.1-pro-preview", "openrouter/xiaomi/mimo-v2-pro"]'
+openclaw config set agents.defaults.heartbeat.model "openrouter/anthropic/claude-haiku-4.5"
 ```
 
 ## History
 
+- **2026-04-10:** Removed `chat` alias — default model is not an alias, it's config.
+  Subscription machines use GPT-5.4 as default (unlimited via ChatGPT subscription).
+  OpenRouter-only machines fall back to Sonnet.
+- **2026-04-08:** Reverted chat/default primary back to Sonnet — Haiku quality was
+  noticeably worse in practice. Heartbeat stays Haiku (cost-appropriate for pings).
+- **2026-04-07:** Heart-centered model selection overhaul. Replaced Sonnet with Haiku
+  for chat (67% savings, vision support, same agentic score). Added EQ-Bench v3 scoring
+  as selection criteria. Introduced subscription overlay (codex/GPT-5.4). New value
+  models: Step 3.5 Flash (cheap), MiniMax M2.7 (simple), MiMo-V2-Pro (work). Grok
+  replaces Qwen for verify (web-grounded fact-checking).
 - **2026-04-04:** Migrated from direct Anthropic API to OpenRouter after Anthropic cut
   off third-party tool access to Claude subscriptions. Old aliases (`haiku`, `sonnet`,
   `opus`) replaced with role-based names.

--- a/knowledge/model-aliases.md
+++ b/knowledge/model-aliases.md
@@ -34,7 +34,7 @@ Requires an `openai-codex` auth profile with OAuth mode.
 
 Machines without a subscription fall back to Sonnet as the default.
 
-- **Primary:** `openrouter/anthropic/claude-sonnet-4-6`
+- **Primary:** `openrouter/anthropic/claude-sonnet-4.6`
 - **Fallback 1:** `chat-fallback` (openrouter/google/gemini-3.1-pro-preview)
 - **Fallback 2:** `work` (openrouter/xiaomi/mimo-v2-pro)
 - **Heartbeat:** `openrouter/anthropic/claude-haiku-4.5`
@@ -102,7 +102,7 @@ openclaw config set agents.defaults.heartbeat.model "openai-codex/gpt-5.4"
 ### Default model — OpenRouter only
 
 ```bash
-openclaw config set agents.defaults.model.primary "openrouter/anthropic/claude-sonnet-4-6"
+openclaw config set agents.defaults.model.primary "openrouter/anthropic/claude-sonnet-4.6"
 openclaw config set agents.defaults.model.fallbacks '["openrouter/google/gemini-3.1-pro-preview", "openrouter/xiaomi/mimo-v2-pro"]'
 openclaw config set agents.defaults.heartbeat.model "openrouter/anthropic/claude-haiku-4.5"
 ```


### PR DESCRIPTION
## Summary

- Overhaul `knowledge/model-aliases.md` to select models on EQ-Bench v3 scores alongside cost and capability
- Introduce a subscription-machine overlay: GPT-5.4 via `openai-codex` as the default on ChatGPT-subscribed machines; OpenRouter-only machines fall back to Sonnet
- Remove the `chat` alias entirely — the default model is config, not an alias
- Replace prior picks with higher-EQ equivalents: Step 3.5 Flash (`cheap`), MiniMax M2.7 (`simple`), MiMo-V2-Pro (`work`), Grok 4.20 (`verify`)
- Add a cost ladder, EQ benchmark table, and install recipes for both machine classes

## Test plan

- [ ] Apply new aliases to one machine and confirm each alias resolves
- [ ] Verify `openai-codex` OAuth flow on a subscription machine
- [ ] Spot-check a cron job that uses an overhauled alias still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)