### PR TITLE
docs: add OpenClaw → Claude Code migration analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@
 /tmp/
 Thumbs.db
 __pycache__/
+drafts/
 uv.lock

--- a/knowledge/claude-code-capabilities.md
+++ b/knowledge/claude-code-capabilities.md
@@ -1,0 +1,355 @@
+# Claude Code Capabilities
+
+Complete inventory of Claude Code features relevant to replacing or supplementing a
+persistent AI assistant service. Written to support migration analysis from OpenClaw.
+
+**Last updated:** 2026-04-09
+
+**Important caveat:** Claude Code is evolving rapidly. Some features described here are
+in research preview or recently launched. Verify current status before making
+architectural decisions.
+
+---
+
+## Architecture
+
+Claude Code is an **interactive CLI tool** — you invoke it, it does work, it exits. It
+is not a daemon or persistent service.
+
+- Runs in a terminal session (or IDE extension, desktop app, web app)
+- Session-scoped: state exists during the conversation, cleared on exit
+- Powered by Claude models (Opus, Sonnet, Haiku) via Anthropic API or subscription
+- Available as: CLI (`claude`), VS Code extension, JetBrains plugin, desktop app
+  (Mac/Windows), web app (claude.ai/code)
+
+**Key architectural property:** Claude Code is designed for software engineering tasks.
+It's a coding assistant, not a general-purpose AI gateway. Features like scheduling and
+channels extend it beyond coding, but the core design assumes a developer at the
+keyboard.
+
+---
+
+## Scheduled Tasks and Remote Triggers
+
+Claude Code offers three scheduling mechanisms:
+
+### Remote Triggers (Cloud-Hosted)
+
+- Created via web UI (`claude.ai/code/scheduled`) or `/schedule` CLI skill
+- Run on **Anthropic's cloud infrastructure** — not on your local machine
+- Standard cron expressions for scheduling
+- Each run is a fresh session (no state carried between runs)
+- Can access MCP servers configured for the task
+- Tied to a GitHub repository for context
+- Auto-expire after 7 days of inactivity (configurable)
+
+**Strengths:** No machine to keep running, Anthropic manages infrastructure, survives
+your laptop being off.
+
+**Limitations:** Cannot access local files, local APIs, or SSH into machines. No model
+fallback chains. No consecutive error tracking. No timeout management beyond the
+platform default. State between runs requires external storage (GitHub, API calls).
+
+### Desktop App Scheduled Tasks
+
+- Visual scheduling in the Claude Code desktop app
+- Runs locally on your machine
+- Persists while the app is running — **lost if the app closes or machine restarts**
+- More like a fancy cron UI than a service
+
+### /loop Skill (Session-Scoped)
+
+- Runs a prompt on a repeating interval within the current session
+- `claude --loop 10m "your prompt"` — repeats every 10 minutes
+- Dies when the session ends
+- Useful for watching deployments, polling CI, monitoring builds
+- Not a cron replacement — it's a temporary polling tool
+- Auto-expires after 3 days
+
+---
+
+## Channels
+
+Claude Code can receive messages from external platforms:
+
+### Native Slack Integration
+
+- Claude appears as a bot in Slack workspaces
+- Responds to @mentions and DMs
+- Coding-focused — designed for development team collaboration
+- Runs within the Claude Code subscription (no additional API cost)
+
+### Channels Feature (Research Preview)
+
+- Supported platforms: **Telegram, Discord, iMessage** (as of early 2026)
+- Activated via `--channels` flag when starting Claude Code
+- **Session-scoped** — channels only work while the Claude Code process is running
+- No built-in daemon mode — requires wrapping in `tmux`/`screen` or a process manager
+  for persistence
+- WhatsApp is NOT natively supported (community MCP connectors exist)
+- Still in research preview — breaking API changes expected
+
+### Community/Third-Party Bridges
+
+- Various community projects bridge Claude Code to additional platforms
+- MCP servers exist for some messaging platforms
+- These are not officially supported and may break with updates
+
+**Key gap vs OpenClaw:** Claude Code channels require an active process. There's no
+"start and walk away" mode. You either keep a terminal open or wrap it in a process
+manager yourself. OpenClaw's channels are built into a daemon that the OS keeps alive.
+
+---
+
+## Hooks
+
+Event-driven automation that fires during Claude Code sessions:
+
+### Hook Types
+
+| Hook         | When It Fires                  | Can Modify Behavior                        |
+| ------------ | ------------------------------ | ------------------------------------------ |
+| PreToolUse   | Before Claude executes a tool  | Yes — block, modify inputs, inject context |
+| PostToolUse  | After a tool executes          | Yes — validate, transform, notify          |
+| SessionStart | When session begins or resumes | Yes — inject environment, load context     |
+
+### Configuration
+
+Hooks live in settings files (project or global):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "your-script.sh" }]
+      }
+    ]
+  }
+}
+```
+
+### Key Properties
+
+- **Persistent across sessions** — configured once, apply to all future sessions
+- **Synchronous execution** — shell commands that block until complete
+- **Can trigger external actions** — send notifications, call APIs, run scripts
+- Hook commands receive tool inputs via environment variables
+- Exit codes control behavior: 0 = success, 2 = block with error
+
+### Relevance for Migration
+
+Hooks are powerful for local automation but only fire during active sessions. They can't
+replace OpenClaw's always-on event processing. However, combined with scheduled tasks,
+hooks could automate some workflow-like behaviors.
+
+---
+
+## Memory and Persistence
+
+Claude Code persists information across sessions through several mechanisms:
+
+### CLAUDE.md Hierarchy
+
+- `~/.claude/CLAUDE.md` — global instructions (all projects)
+- `<project>/CLAUDE.md` — project-level instructions (checked into git)
+- `<project>/CLAUDE.local.md` — local overrides (gitignored)
+- Loaded automatically at session start
+- This is the primary mechanism for persistent identity and instructions
+
+### Auto-Memory
+
+- Claude saves notes to `~/.claude/projects/<project>/memory/` automatically
+- Triggered by learning something important about the user, project, or preferences
+- Persists across sessions within the same project
+- Memory index (MEMORY.md) loaded into every conversation
+- Individual memory files loaded on relevance
+
+### Session Summaries
+
+- Claude auto-compresses conversation history as context fills up
+- Previous conversation context is available when starting a new session
+- Not perfect recall — lossy compression
+
+### What's Missing vs OpenClaw
+
+- **No vector search** — Claude Code memory is file-based, not semantically searchable
+- **No SQLite backend** — no structured queries over memory
+- **No tiered architecture** — no automatic promotion from observations to durable
+  knowledge
+- **No shared memory across projects** — each project has its own memory silo (though
+  global CLAUDE.md spans all)
+- **No embeddings infrastructure** — no LM Studio integration, no semantic recall
+
+---
+
+## Skills and Plugins
+
+### Skills
+
+- Reusable knowledge bundles that extend Claude Code's capabilities
+- Invoked via `/skill-name` syntax
+- Can be defined per-project or globally
+- Contain prompts, instructions, and tool patterns
+- Lightweight — typically 30-50 tokens of instruction
+
+### Plugins
+
+- Shareable bundles of skills + hooks + MCP servers + commands
+- Installable from a marketplace or local paths
+- Can add new capabilities to Claude Code (e.g., the `ai-coding-config` plugin)
+- Plugins define hooks that fire automatically
+
+### Relevance for Migration
+
+OpenClaw skills (standalone Python scripts) are structurally different from Claude Code
+skills (prompt/instruction bundles). However, Claude Code can invoke Python scripts via
+Bash, and MCP servers can wrap external tools. The skill _content_ is portable; the
+_invocation mechanism_ changes.
+
+---
+
+## MCP Servers (Model Context Protocol)
+
+MCP extends Claude Code with external tool access:
+
+- **Protocol:** Standardized interface for tools, resources, and prompts
+- **Available servers:** GitHub, Slack, Sentry, Postgres, Figma, Playwright, filesystem,
+  and many more
+- **Configuration:** Per-project or global in settings files
+- **Lazy loading:** Tools are loaded on-demand to save context
+- **Custom servers:** You can build your own MCP server for any API or tool
+
+### Relevance for Migration
+
+MCP servers could replace some OpenClaw skills (e.g., an MCP server wrapping the
+Parallel API, or Fireflies API). The difference: OpenClaw skills are invoked by the
+gateway daemon; MCP servers are invoked during Claude Code sessions. For scheduled
+tasks, remote triggers can use MCP servers configured for the task.
+
+---
+
+## CLI Automation
+
+Claude Code can be invoked programmatically:
+
+| Command                      | Purpose                                |
+| ---------------------------- | -------------------------------------- |
+| `claude --message "prompt"`  | Send a single message, get response    |
+| `claude --print "prompt"`    | Non-interactive mode, prints response  |
+| `claude --loop 10m "prompt"` | Repeat prompt on interval              |
+| `claude --channels`          | Start with messaging channel listeners |
+| `claude --resume`            | Resume previous session                |
+
+These commands enable scripting Claude Code into cron jobs, shell scripts, or other
+automation. A cron job could run `claude --message "check the inbox"` on a schedule —
+but each invocation starts a fresh session without memory of the previous run (unless
+`--resume` is used).
+
+---
+
+## Agent SDK
+
+Anthropic provides SDKs for building custom agents:
+
+### SDK Capabilities
+
+- Available in Python and TypeScript
+- Wraps the Anthropic API with agent-specific features (tool calling, sessions, loops)
+- Sessions can be persisted to disk and resumed later
+- Supports custom tools and MCP server integration
+- Open-source, self-hosted
+
+### Managed Agents API
+
+- Cloud-hosted agent infrastructure via `/v1/agents` and `/v1/sessions`
+- Long-running conversation threads that persist across API calls
+- Sessions resumable indefinitely via `session_id`
+- Webhook support for receiving external events
+- Anthropic manages infrastructure
+
+### Relevance for Migration
+
+The Agent SDK is the most viable path to building an "OpenClaw-like" service on top of
+Anthropic's infrastructure. You could build a custom gateway using the SDK that handles
+messaging channels, scheduling, and memory. But this means building a new gateway, not
+using Claude Code directly.
+
+---
+
+## Background Agents and Worktrees
+
+### Subagents
+
+- Claude Code can dispatch work to subagents within a session
+- Each subagent runs with its own context, returns results
+- Useful for parallel research, code review, implementation
+
+### Git Worktrees
+
+- Agents can work in isolated git worktrees
+- Changes are committed to separate branches
+- Worktree is auto-cleaned if no changes are made
+
+### Relevance for Migration
+
+These are development features, not personal-assistant features. They're valuable for
+the coding use case but don't map to OpenClaw's workflow system.
+
+---
+
+## Identity and Configuration
+
+Claude Code's identity system maps partially to OpenClaw's:
+
+| OpenClaw     | Claude Code         | Notes                                      |
+| ------------ | ------------------- | ------------------------------------------ |
+| AGENTS.md    | CLAUDE.md (project) | Direct equivalent — workspace instructions |
+| SOUL.md      | CLAUDE.md (global)  | Personality goes in global instructions    |
+| USER.md      | CLAUDE.md (global)  | User profile in global instructions        |
+| BOOT.md      | SessionStart hook   | Can inject context on session start        |
+| HEARTBEAT.md | No equivalent       | No periodic check system                   |
+| TOOLS.md     | CLAUDE.local.md     | Machine-specific config                    |
+| IDENTITY.md  | No equivalent       | No quick-reference card mechanism          |
+
+**Key difference:** OpenClaw's identity templates are separate files with distinct
+purposes. Claude Code collapses everything into the CLAUDE.md hierarchy. This works for
+a single user on a single machine, but doesn't scale to fleet deployment where each
+instance needs different personality/identity files.
+
+---
+
+## Multi-User / Fleet Considerations
+
+Claude Code is designed as a **single-user tool:**
+
+- One Claude Code instance per user account
+- No built-in multi-tenant support
+- No fleet management or remote deployment features
+- `CLAUDE_CONFIG_DIR` can point to different config directories (workaround for per-user
+  isolation, not an official multi-user feature)
+
+**For fleet use cases,** the options are:
+
+1. Run separate Claude Code instances per user on separate machines (same topology as
+   OpenClaw fleet, but more manual management)
+2. Use the Agent SDK to build a multi-tenant service (effectively building a new
+   OpenClaw)
+3. Use Claude Managed Agents API for cloud-hosted multi-user agents (offloads
+   infrastructure to Anthropic)
+
+---
+
+## Cost Model
+
+- **Claude Code Pro subscription:** Included with Claude Pro ($20/month) — covers
+  interactive use and some scheduled tasks
+- **API usage beyond subscription:** Per-token pricing applies
+- **Remote triggers:** Run within subscription quota
+- **Agent SDK / Managed Agents:** Standard API pricing (per-token)
+
+**vs OpenClaw:** OpenClaw uses API keys directly (pay per token). The Max subscription
+previously provided unlimited tokens — now that it's gone, OpenClaw and Claude Code are
+on similar pricing (per-token), but Claude Code's subscription covers interactive use
+that would otherwise be API-billed.

--- a/knowledge/migration-analysis.md
+++ b/knowledge/migration-analysis.md
@@ -8,8 +8,7 @@ OpenClaw functionality to Claude Code.
 **Context:** Anthropic discontinued the Max subscription that provided unlimited API
 access for OpenClaw. With per-token pricing now the only option, the question is whether
 Claude Code (included with Pro subscription) can absorb some or all of OpenClaw's
-workload — both for Nick's personal instance (Cora) and for fleet users (Ali, Gil,
-Julianna, Thomas).
+workload — both for the admin's primary instance and for fleet users.
 
 ---
 
@@ -254,7 +253,7 @@ outages happen regularly. Without fallback chains, you'll see more failures.
 ### Persistent Memory with Semantic Search
 
 OpenClaw's memory system includes vector search via embeddings (LM Studio locally,
-OpenAI fallback). This enables semantic recall: "What did Nick say about the auth
+OpenAI fallback). This enables semantic recall: "What did the user say about the auth
 migration?" finds relevant memories even without exact keyword matches.
 
 Claude Code's memory is file-based with no semantic search. You can grep for keywords,
@@ -332,21 +331,21 @@ Significant capability regression for fleet users
 
 ## Fleet Implications
 
-The migration calculus is different for Nick vs fleet users:
+The migration calculus is different for the admin vs fleet users:
 
-### For Nick (Cora)
+### For the Admin (Primary Instance)
 
-Nick is a developer who's already running Claude Code. The integration is natural:
+The admin is a developer who's already running Claude Code. The integration is natural:
 
-- He's at the keyboard most of the day (channels work during sessions)
+- At the keyboard most of the day (channels work during sessions)
 - Fleet management already runs from Claude Code
-- His skills and workflows can be invoked directly
-- CLAUDE.md already has his personality and preferences
+- Skills and workflows can be invoked directly
+- CLAUDE.md already has personality and preferences
 
-**What he loses:** Always-on WhatsApp/iMessage when AFK, background cron jobs running
+**What they lose:** Always-on WhatsApp/iMessage when AFK, background cron jobs running
 while sleeping, auto-remediation of issues overnight.
 
-### For Fleet Users (Ali, Gil, Julianna, Thomas)
+### For Fleet Users
 
 Fleet users are NOT developers. They interact with their AI via messaging channels. They
 don't open terminals. They don't run Claude Code.
@@ -374,7 +373,7 @@ Or migrate them to Claude's Slack integration if they use Slack.
 ### Current Model (OpenClaw + API)
 
 - Per-token API pricing for all gateway usage
-- Nick's fleet: ~6 machines, each running scheduled jobs + handling messages
+- Example fleet: ~6 machines, each running scheduled jobs + handling messages
 - No subscription fees for the gateway itself (open source)
 - Cost is proportional to usage (busy instances cost more)
 

--- a/knowledge/migration-analysis.md
+++ b/knowledge/migration-analysis.md
@@ -1,0 +1,467 @@
+# Migration Analysis: OpenClaw → Claude Code
+
+Gap analysis, capability mapping, workarounds, and recommendations for migrating
+OpenClaw functionality to Claude Code.
+
+**Last updated:** 2026-04-09
+
+**Context:** Anthropic discontinued the Max subscription that provided unlimited API
+access for OpenClaw. With per-token pricing now the only option, the question is whether
+Claude Code (included with Pro subscription) can absorb some or all of OpenClaw's
+workload — both for Nick's personal instance (Cora) and for fleet users (Ali, Gil,
+Julianna, Thomas).
+
+---
+
+## Executive Summary
+
+Claude Code can absorb **a meaningful portion** of OpenClaw's functionality, but not all
+of it. The viability depends heavily on which capabilities matter most:
+
+- **Scheduling and automation** — Claude Code's remote triggers and `/loop` cover basic
+  cron use cases. The gap is in stateful workflows that accumulate knowledge between
+  runs.
+- **Memory and identity** — CLAUDE.md hierarchy is a strong replacement for OpenClaw's
+  template system. Auto-memory covers some of the tiered memory architecture. The gap is
+  semantic search.
+- **Messaging channels** — This is the biggest gap. Claude Code's channels feature is
+  session-scoped and limited to Telegram/Discord. WhatsApp and iMessage require the
+  gateway or a custom bridge.
+- **Fleet management** — The fleet commands already run from Claude Code (this repo's
+  `.claude/commands/`). Fleet management is portable.
+- **Skills** — Most OpenClaw skills are API wrappers that work anywhere Python runs.
+  Easily portable.
+
+**The fundamental tension:** OpenClaw is a daemon (always on, accepts events). Claude
+Code is a CLI (invoked, does work, exits). This isn't an absolute blocker — remote
+triggers, channels, and process managers can bridge the gap — but it changes the
+operational model significantly.
+
+---
+
+## Capability Mapping Matrix
+
+| OpenClaw Capability              | Claude Code Equivalent              | Gap Level | Notes                                                            |
+| -------------------------------- | ----------------------------------- | --------- | ---------------------------------------------------------------- |
+| **Always-on gateway**            | No equivalent (CLI, session-based)  | High      | Can be partially bridged with remote triggers + process managers |
+| **WhatsApp channel**             | No native support                   | High      | Requires custom bridge or keeping gateway for WhatsApp only      |
+| **iMessage channel**             | Channels feature (research preview) | Medium    | Exists but session-scoped, requires active process               |
+| **Telegram channel**             | Channels feature (research preview) | Medium    | Works but session-scoped, not daemon-managed                     |
+| **Slack channel**                | Native Slack integration            | Low       | Claude Code's Slack support is solid                             |
+| **Cron runner (basic)**          | Remote triggers                     | Low       | Standard cron expressions, cloud-hosted                          |
+| **Cron runner (advanced)**       | No equivalent                       | High      | No fallback chains, cooldown tracking, error counting            |
+| **Model fallback chains**        | No equivalent                       | High      | Claude Code uses one model per session                           |
+| **Provider routing**             | No equivalent                       | High      | No Anthropic/OpenRouter/etc routing                              |
+| **Memory (MEMORY.md)**           | CLAUDE.md + auto-memory             | Low       | Good functional equivalent                                       |
+| **Memory (daily observations)**  | Auto-memory                         | Medium    | Different structure, no tiered promotion                         |
+| **Memory (vector search)**       | No equivalent                       | High      | No embeddings, no semantic search                                |
+| **Memory (SQLite)**              | No equivalent                       | High      | No structured query over memory                                  |
+| **Workflow state (agent_notes)** | No equivalent between runs          | High      | Remote triggers are stateless per-run                            |
+| **Workflow learning loop**       | No equivalent                       | High      | No correction → pattern → promotion pipeline                     |
+| **Skills (Python scripts)**      | Bash tool / MCP servers             | Low       | Scripts run fine; invocation mechanism changes                   |
+| **Identity templates**           | CLAUDE.md hierarchy                 | Low       | Direct mapping, different file structure                         |
+| **SOUL.md personality**          | Global CLAUDE.md                    | Low       | Works well for single user                                       |
+| **BOOT.md startup**              | SessionStart hook                   | Low       | Good equivalent                                                  |
+| **HEARTBEAT.md**                 | /loop or remote triggers            | Medium    | Can approximate with scheduled checks                            |
+| **Fleet management**             | Already runs from Claude Code       | None      | Fleet commands are in this repo                                  |
+| **Health monitoring**            | Remote triggers (basic)             | Medium    | Can poll, but no auto-remediation framework                      |
+| **Security audits**              | Remote triggers + SSH               | Medium    | Can run, but no baseline/drift system                            |
+| **Dashboard (web UI)**           | No equivalent                       | Medium    | No real-time monitoring UI                                       |
+| **Multi-agent coordination**     | Subagents within session            | Medium    | Different model — session-scoped, not cross-gateway              |
+| **Notification routing**         | Hooks + external scripts            | Medium    | Can notify, but no two-lane routing framework                    |
+
+### Gap Level Summary
+
+- **None / Low:** 8 capabilities (easily portable or already working)
+- **Medium:** 8 capabilities (partial coverage, workarounds needed)
+- **High:** 8 capabilities (significant gaps, major workarounds or not possible)
+
+---
+
+## Deep Dive: What Maps Cleanly
+
+### Fleet Management — Already Done
+
+The fleet commands (`/fleet`, `/update-model`, `/fleet-announce`) already run from
+Claude Code via this repo's `.claude/commands/`. Fleet management is SSH-based and
+doesn't depend on the OpenClaw gateway. **This requires zero migration work.**
+
+### Skills — Trivially Portable
+
+OpenClaw skills are standalone scripts. They run via `uv run` with inline dependencies.
+Claude Code can invoke them via the Bash tool or wrap them as MCP servers. The only
+change is invocation context:
+
+- OpenClaw: gateway invokes skill during conversation or cron job
+- Claude Code: user or scheduled task invokes skill during session
+
+**Migration path:** No changes to skill code. Just invoke differently.
+
+### Identity and Personality — Good Mapping
+
+OpenClaw's template system maps to Claude Code's CLAUDE.md hierarchy:
+
+| OpenClaw  | Claude Code         | Migration                                   |
+| --------- | ------------------- | ------------------------------------------- |
+| AGENTS.md | CLAUDE.md (project) | Copy workspace instructions                 |
+| SOUL.md   | CLAUDE.md (global)  | Merge personality into global instructions  |
+| USER.md   | CLAUDE.md (global)  | Merge user profile into global instructions |
+| BOOT.md   | SessionStart hook   | Convert startup routine to hook script      |
+| TOOLS.md  | CLAUDE.local.md     | Copy machine-specific config                |
+
+**Trade-off:** OpenClaw's separation (SOUL.md vs USER.md vs AGENTS.md) is cleaner for
+fleet deployment where each instance needs different files. Claude Code's CLAUDE.md
+collapses everything, which works for single-user but makes fleet per-user customization
+harder.
+
+### Basic Scheduling — Covered
+
+For simple "run this prompt at this time" jobs, Claude Code's remote triggers work:
+
+- Standard cron expressions
+- Cloud-hosted (no machine to keep running)
+- MCP servers available for tool access
+
+Jobs like "daily briefing at 8 AM" or "check for updates at 9 AM" translate directly.
+
+### Slack Integration — Better in Claude Code
+
+Claude Code's native Slack integration is arguably superior to OpenClaw's for
+development teams. It's designed for Slack, well-maintained, and included in the
+subscription.
+
+---
+
+## Deep Dive: Partial Coverage
+
+### Telegram and iMessage Channels
+
+Claude Code's channels feature supports Telegram and iMessage, but:
+
+- **Session-scoped** — requires an active Claude Code process
+- **No built-in daemon mode** — you'd need to wrap it in tmux/screen + launchd/systemd
+- **Research preview** — breaking changes expected
+
+**Workaround:** Run `claude --channels` as a launchd service on the Mac Minis. This
+approximates OpenClaw's always-on channel behavior but with more fragile process
+management. You'd need:
+
+1. A launchd plist that starts `claude --channels` on boot
+2. Restart logic for crashes
+3. CLAUDE.md configuration for the instance's personality/context
+4. Monitoring to detect when the process dies
+
+**Assessment:** Doable but more operational overhead than OpenClaw's built-in daemon.
+
+### Health Monitoring
+
+Remote triggers can run health check prompts on a schedule. But OpenClaw's health check
+system includes:
+
+- Auto-remediation (restart gateway, clear logs, fix stuck jobs)
+- Consecutive error tracking with escalation thresholds
+- Silent success model
+- Integration with the gateway's internal state
+
+**Workaround:** Write a health check script that remote triggers invoke. Use external
+state storage (a file in a GitHub repo, or a simple API) to track consecutive errors.
+Send notifications via hook scripts.
+
+**Assessment:** The basic polling works. The auto-remediation and state tracking require
+custom engineering.
+
+### Workflow Approximation (Stateless)
+
+Simple workflows that don't need state between runs can use remote triggers:
+
+- Daily briefing (calendar-steward) — just runs a prompt with today's context
+- LLM usage report — queries data and formats a report
+- Update checker — checks for new versions
+
+**What breaks:** Workflows that accumulate knowledge (`agent_notes.md`), learn from
+corrections (learning-loop), or maintain processing state (email-steward tracking which
+emails were already handled).
+
+### Multi-Agent Coordination
+
+OpenClaw supports cross-gateway agent coordination via Slack @-mentions. Claude Code has
+subagents within a session but no cross-instance coordination.
+
+**Workaround:** Use Slack as the coordination bus (same pattern as OpenClaw's
+`multi-agent-slack-bus.json`). Each Claude Code instance monitors a Slack channel and
+responds to @-mentions. This actually works similarly to the OpenClaw model.
+
+---
+
+## Deep Dive: Real Gaps
+
+### WhatsApp
+
+Claude Code has no WhatsApp support — not in channels, not in MCP, not in any official
+integration. WhatsApp requires a linked device with persistent WebSocket connection,
+which requires a daemon.
+
+**Workarounds:**
+
+1. **Keep OpenClaw running just for WhatsApp** — use Claude Code for everything else
+2. **Build a WhatsApp bridge** — a small Node.js service that receives WhatsApp messages
+   and forwards them to Claude Code via `claude --message` or the Agent SDK
+3. **Use a third-party WhatsApp API** (Twilio, MessageBird) with an MCP server
+4. **Accept the loss** — if WhatsApp isn't critical for fleet users
+
+**Assessment:** None of these are great. Option 1 defeats the purpose of migrating.
+Option 2 means building a mini-gateway. Options 3-4 depend on use case.
+
+### Stateful Workflows (Learning Loop)
+
+OpenClaw's most distinctive feature is workflows that get smarter over time:
+
+- Corrections are captured in structured format
+- Patterns are detected (2+ similar corrections)
+- Validated patterns promote to MEMORY.md or agent_notes.md
+- Old patterns decay and get pruned
+
+Claude Code has no equivalent. Auto-memory captures some learnings, but there's no
+systematic correction → pattern → promotion pipeline.
+
+**Workaround:** Build a `learning-loop` equivalent as a Claude Code plugin that:
+
+- Stores corrections in a file
+- Runs pattern detection on a schedule (via remote trigger)
+- Updates CLAUDE.md with validated learnings
+
+**Assessment:** The architecture is possible but would require significant custom
+development. And it wouldn't be as tightly integrated as OpenClaw's version.
+
+### Model Routing and Fallback Chains
+
+OpenClaw's provider routing is critical for cost optimization and reliability:
+
+- Role-based aliases select models by capability tier
+- Fallback chains try alternative providers on failure
+- Cooldown tracking avoids hammering rate-limited providers
+- Per-job model specification allows cost optimization
+
+Claude Code uses one model per session (the one your subscription provides). There's no
+fallback, no provider routing, no cost-tier selection.
+
+**Workaround:** For remote triggers, you can specify which model to use. But there's no
+automatic failover. If the model is down, the trigger fails.
+
+**Assessment:** This is a real operational reliability gap. In production, provider
+outages happen regularly. Without fallback chains, you'll see more failures.
+
+### Persistent Memory with Semantic Search
+
+OpenClaw's memory system includes vector search via embeddings (LM Studio locally,
+OpenAI fallback). This enables semantic recall: "What did Nick say about the auth
+migration?" finds relevant memories even without exact keyword matches.
+
+Claude Code's memory is file-based with no semantic search. You can grep for keywords,
+but can't do similarity search.
+
+**Workaround:** Build an MCP server that provides vector search over a memory database.
+This is technically feasible — MCP servers can wrap any API. But you'd need to maintain
+the embedding infrastructure separately.
+
+### Advanced Cron Features
+
+OpenClaw's cron runner tracks per-job health:
+
+- Consecutive error count (escalate after N failures)
+- Timeout management (configurable per-job, kills long-running jobs)
+- Last run time and duration
+- Model/provider used for each run
+- Admin notification on state changes
+
+Remote triggers have none of this. A trigger runs or it doesn't. You don't get
+consecutive error tracking, timeout configuration, or health dashboards.
+
+**Workaround:** Build external monitoring. A webhook from remote triggers could post
+results to a monitoring service. But this is building infrastructure.
+
+---
+
+## Workarounds and Hybrid Approaches
+
+### Hybrid: OpenClaw for Channels, Claude Code for Everything Else
+
+Keep a minimal OpenClaw gateway running **only** for WhatsApp and iMessage channels.
+Move all scheduling, workflows, fleet management, and development work to Claude Code.
+
+**Pros:** Preserves the hardest-to-replace capability (always-on messaging) **Cons:**
+Still running the gateway, still paying for the API tokens it uses
+
+### Hybrid: Claude Code + Custom Bridge Service
+
+Build a lightweight bridge service (not a full gateway) that:
+
+- Receives messages from WhatsApp/Telegram/iMessage
+- Invokes Claude Code via `claude --message` or the Agent SDK
+- Sends responses back to the originating channel
+
+**Pros:** Much simpler than OpenClaw's full gateway; single-purpose **Cons:** Still
+custom code to maintain; loses conversation threading; each message is a fresh context
+(no memory of the conversation unless `--resume` is used)
+
+### Hybrid: Agent SDK as the New Gateway
+
+Use the Claude Agent SDK to build a purpose-built replacement for OpenClaw that:
+
+- Runs as a daemon (you build the process management)
+- Connects to messaging channels (you build the adapters)
+- Uses Anthropic's session API for conversation persistence
+- Leverages MCP servers for tool integration
+
+**Pros:** Modern architecture, official SDK, maintained by Anthropic **Cons:** You're
+building a new OpenClaw. This is months of work.
+
+### Full Migration: Accept the Losses
+
+Move entirely to Claude Code, accepting that:
+
+- WhatsApp/iMessage require being at the keyboard (or a tmux wrapper)
+- Workflows lose their learning loop
+- No model fallback chains
+- No health dashboard
+
+**Pros:** Simplest operational model; one subscription covers everything **Cons:**
+Significant capability regression for fleet users
+
+---
+
+## Fleet Implications
+
+The migration calculus is different for Nick vs fleet users:
+
+### For Nick (Cora)
+
+Nick is a developer who's already running Claude Code. The integration is natural:
+
+- He's at the keyboard most of the day (channels work during sessions)
+- Fleet management already runs from Claude Code
+- His skills and workflows can be invoked directly
+- CLAUDE.md already has his personality and preferences
+
+**What he loses:** Always-on WhatsApp/iMessage when AFK, background cron jobs running
+while sleeping, auto-remediation of issues overnight.
+
+### For Fleet Users (Ali, Gil, Julianna, Thomas)
+
+Fleet users are NOT developers. They interact with their AI via messaging channels. They
+don't open terminals. They don't run Claude Code.
+
+**Running Claude Code "for them"** means:
+
+- SSH into their machine, start a Claude Code session with `--channels`
+- Configure CLAUDE.md with their personality and preferences
+- Hope the process doesn't die (or build restart automation)
+- No per-user customization UI — everything is file-based
+
+**What they lose:** The seamless "text your AI anytime" experience. Instead, they'd have
+a less reliable channel connection that depends on a tmux session staying alive. They
+also lose the dashboard, health monitoring, and any workflow that needs state between
+runs.
+
+**Alternative for fleet users:** Run Claude Code remote triggers for their scheduled
+tasks (briefings, reports, reminders) but keep a minimal OpenClaw gateway for messaging.
+Or migrate them to Claude's Slack integration if they use Slack.
+
+---
+
+## Cost Analysis
+
+### Current Model (OpenClaw + API)
+
+- Per-token API pricing for all gateway usage
+- Nick's fleet: ~6 machines, each running scheduled jobs + handling messages
+- No subscription fees for the gateway itself (open source)
+- Cost is proportional to usage (busy instances cost more)
+
+### Claude Code Pro Model
+
+- $20/month per Claude Pro subscription per user
+- Includes interactive use and remote triggers within quota
+- API usage beyond quota at standard per-token pricing
+- For fleet: $20/month × N users (if each gets their own subscription)
+
+### Hybrid Model
+
+- Keep OpenClaw for channels (API costs for message handling)
+- Use Claude Code subscription for development, fleet management, and some scheduling
+- Potentially lower total cost if channel volume is low
+
+### Agent SDK / Managed Agents Model
+
+- Standard API per-token pricing for all usage
+- Cloud hosting costs if using Managed Agents
+- Development cost to build the replacement
+
+**Bottom line on cost:** The Max subscription made OpenClaw essentially free to run
+(unlimited tokens). Without it, both OpenClaw and Claude Code cost per-token for actual
+AI work. Claude Code's Pro subscription adds value if you're already using it for
+development. The incremental cost of running cron jobs through remote triggers (within
+subscription quota) could be lower than running them through the API directly.
+
+---
+
+## Recommendation
+
+### What to Migrate to Claude Code
+
+1. **Fleet management** — Already there. No changes needed.
+2. **Simple scheduled tasks** — Daily briefings, update checks, reports. Remote triggers
+   handle these well.
+3. **Development workflows** — Code review, debugging, implementation. Claude Code's
+   strength.
+4. **Slack interactions** — Claude Code's native Slack support is excellent.
+5. **Identity and configuration** — Migrate templates to CLAUDE.md hierarchy.
+
+### What to Keep on OpenClaw (or Build a Bridge For)
+
+1. **WhatsApp and iMessage channels** — No viable Claude Code replacement. Keep the
+   gateway running for these, or build a thin bridge service.
+2. **Stateful workflows** — email-steward, contact-steward, learning-loop. These need
+   state between runs that remote triggers can't provide.
+3. **Model fallback chains** — Critical for reliability. Keep for production workloads.
+4. **Health monitoring with auto-remediation** — The auto-fix capability can't be
+   replicated with simple scheduled prompts.
+
+### What to Build
+
+1. **Channels wrapper** — If migrating Telegram, wrap `claude --channels` in a launchd
+   service with restart logic and monitoring.
+2. **State persistence layer** — If migrating stateful workflows, build an MCP server or
+   file-based state system that remote triggers can read/write.
+3. **Monitoring** — External health monitoring for Claude Code processes and remote
+   triggers, since there's no built-in observability.
+
+### What to Accept as Lost (or Defer)
+
+1. **Semantic memory search** — Not available in Claude Code. Build an MCP server later
+   if needed, or wait for Anthropic to add it.
+2. **Learning loop** — The correction → pattern → promotion pipeline doesn't translate.
+   Redesign it as a Claude Code plugin if it's valuable enough to justify the work.
+3. **Dashboard** — No web UI for monitoring. Use logs and Slack notifications instead.
+4. **Advanced cron health tracking** — Consecutive error counting, timeout management.
+   Accept simpler monitoring or build external tooling.
+
+---
+
+## Open Questions
+
+These need answers before committing to a migration path:
+
+1. **How much does WhatsApp actually matter for fleet users?** If they primarily use
+   Telegram or Slack, the gap narrows significantly.
+2. **How stable are Claude Code channels in practice?** The research preview label is
+   concerning — is it stable enough for fleet deployment?
+3. **What's the actual token cost of OpenClaw's current workload?** This determines
+   whether Claude Code's subscription quota covers the load or if it's API-priced
+   anyway.
+4. **Are fleet users willing to switch to Slack?** Claude Code's Slack integration is
+   the strongest channel option.
+5. **How much does the learning loop actually improve outcomes?** If corrections are
+   rare, the loss of the learning loop may not matter in practice.
+6. **What's Anthropic's roadmap for channels and daemon mode?** If always-on channels
+   are coming soon, waiting may be the best strategy.

--- a/knowledge/openclaw-capabilities.md
+++ b/knowledge/openclaw-capabilities.md
@@ -1,0 +1,290 @@
+# OpenClaw Capabilities
+
+Complete inventory of what OpenClaw provides as a platform. Written to support migration
+analysis — what would need to be replicated if moving away from the OpenClaw gateway.
+
+**Last updated:** 2026-04-09
+
+---
+
+## Architecture
+
+OpenClaw is a **persistent AI gateway** — a Node.js daemon that runs 24/7 as a system
+service (launchd on macOS, systemd on Linux). It:
+
+- Stays running across reboots (managed by the OS service layer)
+- Accepts messages from multiple channels simultaneously
+- Maintains persistent state (memory, sessions, workflow progress)
+- Executes scheduled jobs via a built-in cron runner
+- Routes requests to LLM providers with fallback chains
+
+The gateway binds to a local port (default 18789) and exposes a web dashboard for
+monitoring. It's a single binary installed via npm.
+
+**Key architectural property:** OpenClaw is always on. It doesn't need a human to start
+a session. Messages arrive, cron jobs fire, health checks run — all without interaction.
+
+---
+
+## Messaging Channels
+
+OpenClaw connects to messaging platforms via persistent adapters:
+
+| Channel  | Transport                 | Auth                              | Notes                                                  |
+| -------- | ------------------------- | --------------------------------- | ------------------------------------------------------ |
+| WhatsApp | WebSocket (linked device) | QR code pairing                   | Requires gateway's WebSocket listener; CLI cannot send |
+| iMessage | AppleScript / local RPC   | macOS login session               | Only works on macOS with logged-in user                |
+| Telegram | Bot API (long polling)    | Bot token + numeric allowFrom IDs | Reliable from CLI and gateway                          |
+| Slack    | Socket mode               | Bot token + app manifest          | Workspace-level auth                                   |
+
+**Key properties:**
+
+- All channels run simultaneously in the same gateway process
+- Messages are routed to the AI agent with full conversation context
+- `allowFrom` controls who can talk to the bot (per-channel authorization)
+- Channels reconnect automatically after network interruptions
+- The gateway handles message threading, typing indicators, read receipts where
+  supported
+
+**What this means for migration:** Any replacement must handle inbound message reception
+from multiple platforms, route them to an AI, and send responses back — all without
+human intervention.
+
+---
+
+## Scheduled Automation (Cron Runner)
+
+OpenClaw includes a built-in cron scheduler that runs jobs on configurable schedules:
+
+**Configuration:** `~/.openclaw/cron/jobs.json` — each job specifies:
+
+- Cron expression (standard POSIX syntax)
+- Model to use (with role-based aliases: `cheap`, `work`, `think`, `verify`)
+- Prompt or workflow to execute
+- Timeout (seconds)
+- Provider routing preferences
+
+**Operational features:**
+
+- **Fallback chains** — if the primary model/provider fails, tries alternatives
+  (Anthropic direct → OpenRouter → other providers)
+- **Cooldown handling** — tracks provider rate limits, skips providers in cooldown
+- **Consecutive error tracking** — counts failures per job, escalates after thresholds
+- **Timeout management** — configurable per-job, kills long-running jobs gracefully
+- **Silent success** — only notifies on failures or state changes, not routine success
+- **Job health visibility** — `openclaw cron status` shows all jobs with last run time,
+  error count, and model used
+
+**Current job inventory (Nick's instance):** 15 active jobs spanning health monitoring,
+email triage, contact management, daily briefings, knowledge curation, and more —
+running from every 15 minutes to weekly schedules.
+
+**What this means for migration:** The cron runner is tightly integrated with the
+gateway (shares auth profiles, provider state, memory). Jobs aren't just "run a prompt"
+— they carry state between runs and benefit from the gateway's model routing.
+
+---
+
+## Memory System
+
+OpenClaw uses a **three-tier memory architecture:**
+
+### Tier 1: MEMORY.md (Always in Context)
+
+- Curated essentials loaded into every conversation
+- ~100 lines max, manually maintained
+- Contains: key facts, active projects, important relationships, critical decisions
+
+### Tier 2: Daily Observations
+
+- `memory/YYYY-MM-DD.md` — raw observations captured throughout the day
+- Today and yesterday auto-load into context
+- Older days available via search
+
+### Tier 3: Deep Knowledge
+
+- Organized by type: `memory/people/`, `memory/projects/`, `memory/topics/`,
+  `memory/decisions/`
+- Vector-searchable via embeddings (LM Studio local or OpenAI fallback)
+- The `librarian` skill promotes durable knowledge upward through tiers
+
+**Persistence:** Memory lives in SQLite (`~/.openclaw/memory/main.sqlite`) for search,
+with markdown files as the human-readable canonical source. Memory persists across all
+sessions, conversations, and restarts.
+
+**Embeddings:** Local embedding model (LM Studio, port 1234) generates vectors for
+semantic search. Fleet machines connect to the master's LM Studio via Tailscale.
+
+**What this means for migration:** Any replacement needs both structured storage (files)
+and semantic search (embeddings). Claude Code has CLAUDE.md and auto-memory but no
+vector search.
+
+---
+
+## Autonomous Workflows
+
+Workflows are long-running autonomous agents that maintain state and learn over time.
+Each workflow has:
+
+- **AGENT.md** — the algorithm definition (upstream-owned, updated via this repo)
+- **State files** — `agent_notes.md` (learned patterns), `rules.md` (user preferences),
+  `logs/` (execution history) — all user-owned, never overwritten
+- **Schedule** — cron expression for when to run
+- **Model selection** — which model to use (cost/capability tradeoff)
+
+### Workflow Inventory
+
+| Workflow          | What It Does                                                                | Schedule               |
+| ----------------- | --------------------------------------------------------------------------- | ---------------------- |
+| email-steward     | Inbox triage — archive noise, surface important mail                        | Every 30 min, 7am-10pm |
+| task-steward      | Classify work, create tasks, execute via sub-agents, QA results             | Every 30 min           |
+| calendar-steward  | Daily briefing with travel logistics and meeting prep                       | 8 AM daily             |
+| contact-steward   | Detect unknown contacts across WhatsApp/iMessage/Quo, classify and organize | 7 AM, 5 PM daily       |
+| cron-healthcheck  | Detect broken cron jobs, auto-remediate common issues                       | Hourly at :05          |
+| learning-loop     | Capture corrections → detect patterns → validate → promote to memory        | 11:30 PM daily         |
+| llm-usage-report  | Daily LLM spend breakdown by session and model                              | 5 PM daily             |
+| daily-report      | Previous day's cost summary                                                 | 5 PM daily             |
+| security-sentinel | Research AI security threats, map to OpenClaw, verify fleet exposure        | Monday 4 AM weekly     |
+| mailroom-steward  | Advanced email routing (not yet implemented)                                | —                      |
+
+**Key workflow properties:**
+
+- Workflows accumulate knowledge via `agent_notes.md` — they get smarter over time
+- User preferences in `rules.md` customize behavior without touching the algorithm
+- Execution logs provide audit trail and debugging
+- Workflows can escalate to the human when confidence is low
+- Prompt injection defenses built into sensitive workflows (email, contacts)
+
+**What this means for migration:** Workflows depend on the gateway's cron runner, memory
+system, and channel access. The learning/state accumulation is the hardest part to
+replicate — it requires persistent storage that survives across runs.
+
+---
+
+## Skills Framework
+
+Skills are standalone tools the AI agent can invoke:
+
+- **Self-contained** — each skill is a standalone UV script (Python) or bash wrapper
+  with inline dependencies (`# /// script` metadata)
+- **No shared code** — zero coupling between skills
+- **SKILL.md** — metadata file describing the skill, version, usage
+- **Deployment** — copied to `~/.openclaw/workspace/skills/` on install/update
+
+### Skill Categories
+
+**Communication:** agentmail (email for AI), quo (business phone), tgcli (Telegram CLI),
+vapi-calls (outbound voice calls)
+
+**Knowledge:** parallel (web search), limitless (lifelog recall), fireflies (meeting
+transcripts), fathom (meeting recordings), librarian (knowledge curation)
+
+**Productivity:** asana (task management), todoist (task management), followupboss (CRM)
+
+**Meta:** openclaw (self-management), gateway-restart (graceful restart),
+smart-delegation (model routing), workflow-builder (design workflows),
+create-great-prompts (prompt engineering guide)
+
+**What this means for migration:** Skills are mostly API wrappers — they'd work in any
+environment that can run Python scripts. The skill framework itself is trivially
+portable. What matters is whether the calling environment (gateway vs Claude Code) can
+invoke them.
+
+---
+
+## Identity and Personality
+
+OpenClaw maintains persistent identity across all interactions:
+
+| Template     | Purpose                                                |
+| ------------ | ------------------------------------------------------ |
+| AGENTS.md    | Workspace definition — how the AI should think and act |
+| SOUL.md      | Personality — essence, name, communication style       |
+| USER.md      | User profile — who the human is, preferences, context  |
+| BOOT.md      | Startup routine — conversation recovery, pre-checks    |
+| HEARTBEAT.md | Periodic checks — inbox, tasks, health (rotated daily) |
+| TOOLS.md     | Machine-specific environment config                    |
+| IDENTITY.md  | Quick reference card (one-page summary)                |
+
+These templates are deployed to `~/.openclaw/workspace/` and loaded into every
+conversation. They create a consistent persona that persists across sessions, channels,
+and restarts.
+
+**What this means for migration:** Claude Code's CLAUDE.md hierarchy (global → project →
+local) serves a similar purpose. The identity templates could be adapted to CLAUDE.md
+files. The main gap is that CLAUDE.md is project-scoped, while OpenClaw's identity is
+global across all interactions.
+
+---
+
+## Fleet Management
+
+OpenClaw supports multi-machine deployments managed from a central "fleet master":
+
+- **Fleet state:** `~/openclaw-fleet/*.md` — one markdown file per remote server with
+  connection details, current state, gaps, and update history
+- **Push model:** Master machine is the source of truth; updates are pushed via SSH
+- **Fleet command:** `/fleet` in Claude Code — assess, update, notify across machines
+- **Graceful restarts:** `gateway-restart` skill ensures zero message loss during
+  updates
+- **Health monitoring:** Each machine runs its own health check cron; master can SSH in
+  for deeper diagnosis
+- **Security audits:** `security-sentinel` workflow SSHs into fleet machines for
+  exposure mapping
+- **Notification routing:** Two-lane model (admin alerts vs user notifications) with
+  per-machine configuration
+
+**What this means for migration:** Fleet management is entirely SSH-based and lives in
+this repo (commands, skills, devops specs). It doesn't depend on the OpenClaw gateway
+itself — it could be operated from Claude Code or any SSH-capable environment. The
+gateway is what gets _managed_, not what does the managing.
+
+---
+
+## Model Routing
+
+OpenClaw routes LLM requests through a sophisticated provider system:
+
+**Role-based aliases:**
+
+- `cheap` / `simple` — fast, inexpensive tasks (Haiku-class)
+- `work` / `chat` — standard quality (Sonnet-class)
+- `think` / `verify` — deep reasoning (Opus-class)
+
+**Provider routing:**
+
+- Anthropic direct API (primary)
+- OpenRouter (fallback, access to non-Anthropic models)
+- Per-job and per-workflow model specification
+- Automatic fallback when primary provider fails or rate-limits
+
+**Cooldown management:** Tracks rate limit state per provider, automatically routes
+around providers in cooldown.
+
+**What this means for migration:** Claude Code uses a single model per session (the one
+you're subscribed to). There's no fallback chain, no provider routing, no cost-tier
+selection. This is a significant capability difference for cost optimization.
+
+---
+
+## Health and Observability
+
+**Health check cron:** Runs every 30 minutes, checking:
+
+- Gateway liveness
+- Model catalog (missing models)
+- Cron job health (consecutive errors, timeouts)
+- Disk and memory usage
+- Log health (rotation, size)
+
+**Auto-remediation:** Common issues are fixed automatically (restart hung gateway, clean
+old logs, clear stuck jobs). Failures escalate to admin via Telegram.
+
+**Logging:** Gateway logs rotate daily (`/tmp/openclaw/openclaw-YYYY-MM-DD.log`), with
+error-only logs at `~/.openclaw/logs/gateway.err.log`.
+
+**Dashboard:** Web UI at `http://127.0.0.1:18789/` for real-time monitoring.
+
+**What this means for migration:** Claude Code has no equivalent observability layer.
+There's no health monitoring, no auto-remediation, no dashboard. You'd be flying blind
+unless you build monitoring externally.

--- a/knowledge/openclaw-config-repo.md
+++ b/knowledge/openclaw-config-repo.md
@@ -28,7 +28,7 @@ specifics. Generic placeholders in all examples.
 ```
 openclaw-config/
 ├── skills/              17 standalone tools (Python UV scripts + bash wrappers)
-├── workflows/           10 autonomous agents with state and learning
+├── workflows/            9 autonomous agents with state and learning
 ├── templates/            8 identity and deployment templates
 ├── devops/               Health check, machine setup, security review, notifications
 ├── knowledge/            Operational documentation and architecture guides
@@ -97,7 +97,7 @@ directory). No shared code, no project-level dependencies.
 
 ---
 
-## Workflows (10)
+## Workflows (9)
 
 Autonomous agents that run on schedules, maintain state, and learn from corrections.
 
@@ -112,7 +112,6 @@ Autonomous agents that run on schedules, maintain state, and learn from correcti
 | cron-healthcheck  | Detect broken cron jobs, auto-remediate common issues. Two-tier model (triage + diagnosis). | AGENT.md, agent_notes.md                 |
 | learning-loop     | Capture corrections → detect patterns → validate → promote to memory.                       | AGENT.md, agent_notes.md, rules.md       |
 | llm-usage-report  | Daily LLM spend breakdown by session and model. Empathy pass for tone.                      | AGENT.md, agent_notes.md, logs/          |
-| daily-report      | Previous day's cost and activity summary.                                                   | AGENT.md, agent_notes.md, logs/          |
 | security-sentinel | Research AI security threats, map to OpenClaw architecture, verify fleet exposure via SSH.  | AGENT.md, agent_notes.md                 |
 | mailroom-steward  | Advanced email routing (not yet implemented — directory exists with logs/ only).            | —                                        |
 
@@ -257,7 +256,7 @@ uv run --with pytest pytest tests/ -v
 ### Test Coverage
 
 **Workflow structure tests:** Validate AGENT.md frontmatter and required sections for
-daily-report, llm-usage-report, fleet-spend-digest workflows.
+llm-usage-report workflow.
 
 **Skill integration tests:** agentmail, fireflies, fathom, limitless, parallel, quo,
 followupboss — all auto-skip without respective API keys.
@@ -272,7 +271,7 @@ correctly.
 This repo is the **shareable brain** for OpenClaw instances:
 
 1. **17 integration skills** — API wrappers for communication, knowledge, productivity
-2. **10 autonomous workflows** — scheduled agents that learn and maintain state
+2. **9 autonomous workflows** — scheduled agents that learn and maintain state
 3. **8 identity templates** — personality, preferences, startup routines
 4. **DevOps specs** — health monitoring, machine setup, security hardening
 5. **Fleet commands** — multi-machine management from Claude Code
@@ -281,7 +280,7 @@ This repo is the **shareable brain** for OpenClaw instances:
 
 **What it does NOT contain:**
 
-- The OpenClaw gateway source code (that's in `moltbot/moltbot` on GitHub)
+- The OpenClaw gateway source code (separate private repository)
 - Fleet-specific data (that's in `~/openclaw-fleet/`, private)
 - Instance-specific configuration (that's in `~/.openclaw/`, per-machine)
 - API keys or credentials (all referenced via environment variables)

--- a/knowledge/openclaw-config-repo.md
+++ b/knowledge/openclaw-config-repo.md
@@ -27,9 +27,9 @@ specifics. Generic placeholders in all examples.
 
 ```
 openclaw-config/
-├── skills/              17 standalone tools (Python UV scripts + bash wrappers)
-├── workflows/            9 autonomous agents with state and learning
-├── templates/            8 identity and deployment templates
+├── skills/              Standalone tools (Python UV scripts + bash wrappers)
+├── workflows/           Autonomous agents with state and learning
+├── templates/           Identity and deployment templates
 ├── devops/               Health check, machine setup, security review, notifications
 ├── knowledge/            Operational documentation and architecture guides
 ├── memory/               Example memory structure (people/, projects/, topics/)
@@ -45,7 +45,7 @@ openclaw-config/
 
 ---
 
-## Skills (17)
+## Skills
 
 Each skill is self-contained: `SKILL.md` (metadata) + executable script (same name as
 directory). No shared code, no project-level dependencies.
@@ -97,7 +97,7 @@ directory). No shared code, no project-level dependencies.
 
 ---
 
-## Workflows (9)
+## Workflows
 
 Autonomous agents that run on schedules, maintain state, and learn from corrections.
 
@@ -141,7 +141,7 @@ Autonomous agents that run on schedules, maintain state, and learn from correcti
 
 ---
 
-## Templates (8)
+## Templates
 
 Identity and configuration files deployed to `~/.openclaw/workspace/`:
 
@@ -270,9 +270,9 @@ correctly.
 
 This repo is the **shareable brain** for OpenClaw instances:
 
-1. **17 integration skills** — API wrappers for communication, knowledge, productivity
-2. **9 autonomous workflows** — scheduled agents that learn and maintain state
-3. **8 identity templates** — personality, preferences, startup routines
+1. **Integration skills** — API wrappers for communication, knowledge, productivity
+2. **Autonomous workflows** — scheduled agents that learn and maintain state
+3. **Identity templates** — personality, preferences, startup routines
 4. **DevOps specs** — health monitoring, machine setup, security hardening
 5. **Fleet commands** — multi-machine management from Claude Code
 6. **Knowledge docs** — model routing, multi-agent patterns, boot sequences

--- a/knowledge/openclaw-config-repo.md
+++ b/knowledge/openclaw-config-repo.md
@@ -1,0 +1,287 @@
+# OpenClaw Config Repository
+
+Complete inventory of what this repository (`openclaw-config`) provides — the shareable
+configuration layer for OpenClaw instances.
+
+**Last updated:** 2026-04-09
+
+---
+
+## What This Repo Is
+
+This is the **upstream source** for all OpenClaw instances. It contains the templates,
+skills, workflows, devops specs, and knowledge that get deployed to live instances. It
+is NOT the OpenClaw gateway code itself — it's the configuration and tooling layer.
+
+**Deployment model:** The `openclaw` skill copies files from this repo to a live
+instance's workspace (`~/.openclaw/workspace/`). Upstream-owned files (algorithms,
+templates, skills) are overwritten on update. User-owned files (rules, notes, logs) are
+never touched.
+
+**Public repo:** This is open-source and intended to be shareable. Zero PII, zero fleet
+specifics. Generic placeholders in all examples.
+
+---
+
+## Repository Structure
+
+```
+openclaw-config/
+├── skills/              17 standalone tools (Python UV scripts + bash wrappers)
+├── workflows/           10 autonomous agents with state and learning
+├── templates/            8 identity and deployment templates
+├── devops/               Health check, machine setup, security review, notifications
+├── knowledge/            Operational documentation and architecture guides
+├── memory/               Example memory structure (people/, projects/, topics/)
+├── tests/                pytest suite for workflows and skill integrations
+├── .claude/
+│   ├── commands/         Claude Code slash commands (fleet, update-model, fleet-announce)
+│   └── settings.json     Hooks and plugin configuration
+├── AGENTS.md             Project instructions (CLAUDE.md is a symlink to this)
+├── CHANGELOG.md          Version history
+├── VERSION               Current version number
+└── README.md             Overview and getting started
+```
+
+---
+
+## Skills (17)
+
+Each skill is self-contained: `SKILL.md` (metadata) + executable script (same name as
+directory). No shared code, no project-level dependencies.
+
+### Communication Skills
+
+| Skill      | Version | What It Does                                                     | Dependencies                    |
+| ---------- | ------- | ---------------------------------------------------------------- | ------------------------------- |
+| agentmail  | 0.1.0   | Email inboxes for AI agents — create addresses, send/receive     | AGENTMAIL_API_KEY               |
+| quo        | 0.6.0   | Business phone via OpenPhone — calls, texts, contacts, voicemail | (configured in OpenPhone)       |
+| tgcli      | 0.1.0   | Read/send Telegram messages via CLI                              | Telegram bot token              |
+| vapi-calls | 0.1.0   | Outbound phone calls via Vapi voice AI                           | VAPI_API_KEY, VAPI_ASSISTANT_ID |
+
+### Knowledge & Research Skills
+
+| Skill     | Version | What It Does                                          | Dependencies       |
+| --------- | ------- | ----------------------------------------------------- | ------------------ |
+| parallel  | 0.3.0   | Web search, content extraction, data enrichment       | PARALLEL_API_KEY   |
+| limitless | 0.2.0   | Query Limitless Pendant lifelogs                      | LIMITLESS_API_KEY  |
+| fireflies | 0.2.0   | Search Fireflies.ai meeting transcripts               | FIREFLIES_API_KEY  |
+| fathom    | 0.1.0   | Query Fathom AI meeting recordings                    | FATHOM_API_KEY     |
+| librarian | 0.3.0   | Knowledge base maintenance — curate, promote, archive | (no external deps) |
+
+### Productivity Skills
+
+| Skill        | Version | What It Does                                     | Dependencies       |
+| ------------ | ------- | ------------------------------------------------ | ------------------ |
+| asana        | 0.1.0   | Manage Asana tasks, projects, workspaces via MCP | ASANA_ACCESS_TOKEN |
+| todoist      | 0.1.0   | Manage Todoist tasks via CLI                     | TODOIST_API_TOKEN  |
+| followupboss | 0.1.0   | Query/manage Follow Up Boss CRM                  | FUB_API_KEY        |
+
+### Meta Skills
+
+| Skill                | Version | What It Does                                    | Dependencies       |
+| -------------------- | ------- | ----------------------------------------------- | ------------------ |
+| openclaw             | 0.3.0   | Install, configure, update openclaw-config      | (no external deps) |
+| gateway-restart      | 0.1.0   | Graceful gateway restart with zero message loss | (no external deps) |
+| smart-delegation     | 0.2.0   | Route tasks to optimal model (cost/capability)  | (no external deps) |
+| workflow-builder     | 0.2.0   | Design and build autonomous workflows           | (no external deps) |
+| create-great-prompts | 2.0.0   | Prompt engineering methodology guide            | (no external deps) |
+
+### Skill Architecture
+
+- **Python skills:** Use `uv run` with inline `# /// script` dependencies — no
+  pyproject.toml, no virtualenv setup needed
+- **Bash skills:** Thin wrappers around external CLIs
+- **Meta skills:** SKILL.md only (instructions/methodology, no executable)
+- **Testing:** Integration tests in `tests/` auto-skip without API keys
+
+---
+
+## Workflows (10)
+
+Autonomous agents that run on schedules, maintain state, and learn from corrections.
+
+### Active Workflows
+
+| Workflow          | What It Does                                                                                | Key Files                                |
+| ----------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| email-steward     | Inbox triage — archive noise, surface important mail. Prompt injection defenses.            | AGENT.md                                 |
+| task-steward      | Classify work, create tasks, execute via sub-agents, QA verification.                       | AGENT.md                                 |
+| calendar-steward  | Daily briefing with travel logistics, meeting prep, conflict detection.                     | AGENT.md                                 |
+| contact-steward   | Detect unknown contacts across WhatsApp/iMessage/Quo, classify, organize.                   | AGENT.md, classifier.md, platforms/\*.md |
+| cron-healthcheck  | Detect broken cron jobs, auto-remediate common issues. Two-tier model (triage + diagnosis). | AGENT.md, agent_notes.md                 |
+| learning-loop     | Capture corrections → detect patterns → validate → promote to memory.                       | AGENT.md, agent_notes.md, rules.md       |
+| llm-usage-report  | Daily LLM spend breakdown by session and model. Empathy pass for tone.                      | AGENT.md, agent_notes.md, logs/          |
+| daily-report      | Previous day's cost and activity summary.                                                   | AGENT.md, agent_notes.md, logs/          |
+| security-sentinel | Research AI security threats, map to OpenClaw architecture, verify fleet exposure via SSH.  | AGENT.md, agent_notes.md                 |
+| mailroom-steward  | Advanced email routing (not yet implemented — directory exists with logs/ only).            | —                                        |
+
+### Workflow File Ownership
+
+**Upstream-owned** (updated by this repo):
+
+- `AGENT.md` — the algorithm definition
+- `classifier.md` — classification logic (where applicable)
+- `platforms/*.md` — platform-specific guides
+
+**User-owned** (never overwritten):
+
+- `rules.md` — user preferences and thresholds
+- `agent_notes.md` — learned patterns (accumulated over time)
+- `preferences.md` — user-specific settings
+- `processed.md` — tracking what's been handled
+- `logs/` — execution history
+
+### Workflow Architecture
+
+- Each workflow is a prompt + context that runs via the cron runner
+- State persists in markdown files between runs
+- `agent_notes.md` accumulates over time — workflows get smarter
+- Corrections feed into `learning-loop`, which promotes patterns back to workflows
+- Workflows can invoke skills (e.g., email-steward uses agentmail)
+
+---
+
+## Templates (8)
+
+Identity and configuration files deployed to `~/.openclaw/workspace/`:
+
+| Template     | Purpose                                                     | Typical Size       |
+| ------------ | ----------------------------------------------------------- | ------------------ |
+| AGENTS.md    | Workspace definition — how the AI should think and act      | ~17K chars         |
+| SOUL.md      | Personality — essence, name, communication style            | Varies by instance |
+| USER.md      | User profile — who the human is, preferences, working style | Varies             |
+| MEMORY.md    | Curated essentials, always loaded into context              | ~100 lines         |
+| BOOT.md      | Startup routine — conversation recovery, pre-checks         | Short              |
+| HEARTBEAT.md | Periodic checks — inbox, tasks, health (rotated daily)      | Medium             |
+| TOOLS.md     | Machine-specific environment config and notes               | Short              |
+| IDENTITY.md  | Quick reference card (one-page identity summary)            | Short              |
+
+**Also:** `multi-agent-slack-bus.json` — configuration template for multi-agent
+coordination via Slack.
+
+---
+
+## DevOps
+
+Infrastructure management specs for fleet machines:
+
+### health-check.md
+
+- Runs every 30 minutes via cron
+- Checks: gateway liveness, model catalog, cron job health, disk/memory, log health
+- Auto-fixes: restarts, hung processes, old logs
+- Escalates: failures to admin via Telegram
+- Silent success model — only notifies on problems
+
+### machine-setup.md (macOS)
+
+Desired-state specification covering:
+
+- Power management (prevent sleep)
+- Permissions, Brewfile, Node.js setup
+- Gateway config and service installation
+- Automated backup with retention
+- Workspace structure and agent defaults
+- Health check admin notification setup
+
+### machine-setup-linux.md
+
+Linux-specific setup:
+
+- Tailscale, SSH hardening
+- System packages, Node.js, pnpm
+- Gateway config with systemd
+- Backup with systemd timers
+- Whisper.cpp for voice transcription
+
+### machine-security-review.md
+
+Two-mode security agent:
+
+- **Drift detection** (daily) — fast check for changes since baseline
+- **Full audit + red team** (weekly) — comprehensive review including adversarial
+  testing
+- Checks: firewall, open ports, file permissions, SSH config, API key exposure, cron
+  integrity, prompt injection, skill script integrity
+- Auto-fixes safe issues, escalates everything else
+
+### notification-routing.md
+
+Two-lane notification model:
+
+- **Lane 1 (Admin):** System health alerts to fleet admin via Telegram
+- **Lane 2 (User):** Cron outputs to the instance's host person
+- Per-machine configuration in `~/.openclaw/health-check-admin`
+
+---
+
+## Commands (.claude/commands/)
+
+Claude Code slash commands for fleet operations:
+
+| Command           | Purpose                                                                        |
+| ----------------- | ------------------------------------------------------------------------------ |
+| fleet.md          | Multi-machine deployment — assess state, push updates, coordinate across fleet |
+| update-model.md   | Change OpenClaw model config with 5-point verification                         |
+| fleet-announce.md | Send personalized announcements to fleet users                                 |
+
+These commands run from the fleet master machine (this repo) and operate on remote
+machines via SSH.
+
+---
+
+## Knowledge Base
+
+Operational documentation in `knowledge/`:
+
+| Document                        | What It Covers                                                      |
+| ------------------------------- | ------------------------------------------------------------------- |
+| model-aliases.md                | Role-based model aliases, cost/EQ benchmarks, subscriber overlays   |
+| model-configs-and-jobs.md       | Model selection, provider routing, fallback chains, cron scheduling |
+| fleet-boot-patterns.md          | Multi-agent coordination, session persistence, loop detection       |
+| multi-agent-communication.md    | Cross-gateway agent coordination via Slack                          |
+| fleet-boot-patterns-research.md | Deep research on bootstrapping, deployment, persistence             |
+| plans/vapi-phone-skill.md       | Design brainstorm for Vapi voice call capability                    |
+
+---
+
+## Testing
+
+pytest-based testing with auto-skip for integration tests:
+
+```bash
+uv run --with pytest pytest tests/ -v
+```
+
+### Test Coverage
+
+**Workflow structure tests:** Validate AGENT.md frontmatter and required sections for
+daily-report, llm-usage-report, fleet-spend-digest workflows.
+
+**Skill integration tests:** agentmail, fireflies, fathom, limitless, parallel, quo,
+followupboss — all auto-skip without respective API keys.
+
+**Skill wrapper tests:** Verify bash/uv wrappers around external CLIs function
+correctly.
+
+---
+
+## What This Repo Provides (Summary)
+
+This repo is the **shareable brain** for OpenClaw instances:
+
+1. **17 integration skills** — API wrappers for communication, knowledge, productivity
+2. **10 autonomous workflows** — scheduled agents that learn and maintain state
+3. **8 identity templates** — personality, preferences, startup routines
+4. **DevOps specs** — health monitoring, machine setup, security hardening
+5. **Fleet commands** — multi-machine management from Claude Code
+6. **Knowledge docs** — model routing, multi-agent patterns, boot sequences
+7. **Test suite** — validation for workflows and skill integrations
+
+**What it does NOT contain:**
+
+- The OpenClaw gateway source code (that's in `moltbot/moltbot` on GitHub)
+- Fleet-specific data (that's in `~/openclaw-fleet/`, private)
+- Instance-specific configuration (that's in `~/.openclaw/`, per-machine)
+- API keys or credentials (all referenced via environment variables)


### PR DESCRIPTION
## Summary

- Add four research documents under `knowledge/` analyzing whether Claude Code (bundled with Pro subscription) could absorb OpenClaw workload after Anthropic discontinued unlimited-API Max subscriptions
- `claude-code-capabilities.md` — Claude Code feature inventory relevant to persistent-gateway replacement
- `openclaw-capabilities.md` — what OpenClaw provides as a platform
- `openclaw-config-repo.md` — inventory of this repo specifically
- `migration-analysis.md` — gap analysis, workarounds, and recommendations for Cora and fleet users
- Add \`drafts/\` to \`.gitignore\` for local analysis scratch space

## Test plan

- [ ] Spot-check each knowledge file renders cleanly on GitHub
- [ ] Confirm no links point to private fleet state or PII

🤖 Generated with [Claude Code](https://claude.com/claude-code)