### PR TITLE
fix(knowledge): replace real name with placeholder in openclaw-capabilities.md

### DIFF
--- a/knowledge/openclaw-capabilities.md
+++ b/knowledge/openclaw-capabilities.md
@@ -75,7 +75,7 @@ OpenClaw includes a built-in cron scheduler that runs jobs on configurable sched
 - **Job health visibility** — `openclaw cron status` shows all jobs with last run time,
   error count, and model used
 
-**Current job inventory (Nick's instance):** 15 active jobs spanning health monitoring,
+**Current job inventory (example instance):** 15 active jobs spanning health monitoring,
 email triage, contact management, daily briefings, knowledge curation, and more —
 running from every 15 minutes to weekly schedules.
 


### PR DESCRIPTION
## Summary

- Replaces `Nick's instance` with `example instance` in `knowledge/openclaw-capabilities.md:78`
- Fixes zero-PII policy violation caught by Cursor Bugbot review of PR #70

## Context

Follow-up to #70 (docs: add OpenClaw → Claude Code migration analysis). Cursor correctly identified that one real name survived the cleanup pass — `knowledge/openclaw-capabilities.md` line 78 still had `Nick's instance` while all other files were properly anonymized.

## Test plan

- [x] Verify no real names remain: `grep -rn "\bNick\b\|\bAli\b\|\bGil\b\|\bJulianna\b\|\bThomas\b\|\bCora\b" knowledge/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)