### PR TITLE
Fix model alias references from PR #69 bot feedback

### DIFF
--- a/devops/cron-fleet-manifest.md
+++ b/devops/cron-fleet-manifest.md
@@ -24,7 +24,7 @@ See `topic-standard.md` for the routing rules and topic definitions.
 | ------------------------------- | ------------------ | -------------- | ------------- | --------------- | ----------------------------- |
 | **DCOS Morning Standup**        | 8am daily          | haiku          | 📋 Automation | announce        |                               |
 | **Daily Intelligence Briefing** | 7am daily          | sonnet         | 📋 Automation | announce        |                               |
-| **Daily EOD Briefing**          | 7pm daily          | grok           | 📋 Automation | announce        |                               |
+| **Daily EOD Briefing**          | 7pm daily          | verify         | 📋 Automation | announce        |                               |
 | **DCOS Weekly Review**          | Sun 6pm            | sonnet         | 📋 Automation | announce        |                               |
 | **Cora's Daily Check-In**       | 10am weekdays      | sonnet         | 🏠 Home       | in-prompt       | Personal, not operational     |
 | **Birthday Check**              | 8am daily          | default        | 📋 Automation | announce        |                               |

--- a/knowledge/model-aliases.md
+++ b/knowledge/model-aliases.md
@@ -28,7 +28,7 @@ Requires an `openai-codex` auth profile with OAuth mode.
 - **Primary:** `openai-codex/gpt-5.4`
 - **Fallback 1:** `chat-fallback` (openrouter/google/gemini-3.1-pro-preview)
 - **Fallback 2:** `work` (openrouter/xiaomi/mimo-v2-pro)
-- **Heartbeat:** `openai-codex/gpt-5.4`
+- **Heartbeat:** `openrouter/anthropic/claude-haiku-4.5`
 
 ### OpenRouter-only machines
 
@@ -96,7 +96,7 @@ openclaw models aliases add verify openrouter/x-ai/grok-4.20
 openclaw auth add openai-codex --mode oauth
 openclaw config set agents.defaults.model.primary "openai-codex/gpt-5.4"
 openclaw config set agents.defaults.model.fallbacks '["openrouter/google/gemini-3.1-pro-preview", "openrouter/xiaomi/mimo-v2-pro"]'
-openclaw config set agents.defaults.heartbeat.model "openai-codex/gpt-5.4"
+openclaw config set agents.defaults.heartbeat.model "openrouter/anthropic/claude-haiku-4.5"
 ```
 
 ### Default model — OpenRouter only


### PR DESCRIPTION
## Summary

Addresses two issues flagged by Cursor Bugbot on PR #69:

- ✅ **Cron job using removed alias**: Daily EOD Briefing referenced `grok` which was removed in #69. Changed to `verify` (uses same grok-4.20 model)
- ✅ **Heartbeat provider independence**: Subscription heartbeat now uses OpenRouter instead of openai-codex for independent health monitoring

## Changes

**devops/cron-fleet-manifest.md**
- Daily EOD Briefing: `grok` → `verify`

**knowledge/model-aliases.md**
- Subscription heartbeat: `openai-codex/gpt-5.4` → `openrouter/anthropic/claude-haiku-4.5` (both docs and install command)

## Why

The `grok` alias was folded into `verify` in #69, but the cron job wasn't migrated. The heartbeat sharing the same provider as primary defeats self-monitoring — if openai-codex goes down, both primary and heartbeat fail, so the system can't detect the outage.

## Test Plan

- [x] Verified `verify` alias exists and uses grok-4.20
- [x] Confirmed subscription heartbeat now uses different provider than primary
- [x] OpenRouter-only config already had this independence (unchanged)

---

Follow-up to TechNickAI/openclaw-config#69
Related bot comments: cursor[bot] #3068543633, #3068543636

🤖 Generated with [Claude Code](https://claude.com/claude-code)