### PR TITLE
fix(forward-motion): prevent table header check from matching bot/group names

### DIFF
--- a/workflows/forward-motion/scripts/scan.py
+++ b/workflows/forward-motion/scripts/scan.py
@@ -130,7 +130,7 @@ def _parse_topic_lines(lines: list[str], human_id: int | None) -> list[dict[str,
 def _parse_bot_lines(lines: list[str]) -> list[dict[str, Any]]:
     bots: list[dict[str, Any]] = []
     for line in lines:
-        if any(line.startswith(prefix) for prefix in ["| Bot", "|-----", "|---"]):
+        if any(line.startswith(prefix) for prefix in ["| Bot |", "|-----", "|---"]):
             continue
         parts = [p.strip() for p in line.split("|")[1:-1]]
         try:
@@ -160,7 +160,7 @@ def _parse_bot_lines(lines: list[str]) -> list[dict[str, Any]]:
 def _parse_group_lines(lines: list[str]) -> list[dict[str, Any]]:
     groups: list[dict[str, Any]] = []
     for line in lines:
-        if any(line.startswith(prefix) for prefix in ["| Group", "|-----", "|---"]):
+        if any(line.startswith(prefix) for prefix in ["| Group |", "|-----", "|---"]):
             continue
         parts = [p.strip() for p in line.split("|")[1:-1]]
         try:


### PR DESCRIPTION
## Summary

Fixes a High Severity bug identified by Cursor Bugbot in PR #72 where bots/groups with names starting with "Bot" or "Group" were silently excluded from the parsed fleet.

## Problem

The header-skip guard used `line.startswith("| Bot")` which incorrectly matched data rows where the bot's name starts with "Bot" (e.g., "BotFather", "Bot-Helper"). These bots were silently dropped from parsing with no error or warning.

## Solution

Changed the header check from:
- `["| Bot", ...]` → `["| Bot |", ...]`
- `["| Group", ...]` → `["| Group |", ...]`

This ensures we match only the actual header column (with pipes on both sides) rather than any name that starts with "Bot"/"Group".

## Test Plan

- [x] Code review - verified the pattern now requires the closing pipe
- [ ] Integration test with a bot named "BotFather" to confirm it's no longer skipped

## Related

- Addresses: TechNickAI/openclaw-config#72 (Cursor Bugbot comment 3069534953)

🤖 Generated with [Claude Code](https://claude.com/claude-code)