### PR TITLE
fix(contact-steward): gate substantive renames behind human approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ invoke), workflows maintain state, learn your preferences, and manage themselves
 | **email-steward**     | Triage inbox — archive noise, label, alert on important                    | 0.3.0   |
 | **task-steward**      | Classify work, create tasks, spawn sub-agents, QA results                  | 0.1.0   |
 | **calendar-steward**  | Daily briefing — travel time, meeting prep, conflict detection             | 0.1.0   |
-| **contact-steward**   | Detect unknown contacts across platforms, classify & organize              | 0.2.0   |
+| **contact-steward**   | Detect unknown contacts across platforms, classify & organize              | 0.2.1   |
 | **security-sentinel** | Threat intelligence research & fleet exposure mapping                      | 0.1.0   |
 | **cron-healthcheck**  | Detect broken cron jobs, auto-remediate, escalate failures                 | 0.1.0   |
 | **learning-loop**     | Self-improvement — capture corrections, detect patterns, promote learnings | 0.1.0   |

--- a/workflows/contact-steward/AGENT.md
+++ b/workflows/contact-steward/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: contact-steward
-version: 0.2.0
+version: 0.2.1
 description:
   Manages contacts across messaging platforms — detects unidentified contacts your human
   is actively engaging with, classifies them, and adds them to the appropriate platform
@@ -16,6 +16,11 @@ contact **on the platform where the conversation is happening**.
 `wacli`, Quo contacts through `quo`, and iMessage contacts through Apple Contacts. Don't
 cross-write — if you find an unknown WhatsApp contact, add them in WhatsApp, not in
 Apple Contacts. See each platform guide for the correct commands.
+
+**Trust rule:** existing saved contact names are sticky. Never fully rename an existing
+contact unless your human explicitly approves that exact rename. Automatic updates are
+limited to light normalization only (case, spacing, punctuation, or emoji cleanup) when
+the canonical name tokens are unchanged.
 
 ## Prerequisites
 
@@ -260,13 +265,15 @@ Before first scan, check `PRAGMA user_version`:
    a. Check processed.db for this platform + contact_id. b. If found, not an `error`,
    and no new messages since last_checked → skip. c. If found with status `error` →
    treat as new, retry (counts toward cap). d. Is the other party a saved contact on
-   this platform? Check for enrichment (new messages with contact-relevant info). If no
-   new info, update last_checked and skip. e. Not a saved contact? Cross-reference the
-   phone number on other platforms (especially `wacli contacts search <number>`) f.
-   Found info (cross-reference match, profile name, or conversation clues)? Spawn the
-   work tier with everything you gathered. It verifies and writes the contact. g. No
-   match anywhere? Spawn the work tier with full conversation context for detective
-   work.
+   this platform? Check for enrichment (new messages with contact-relevant info). If the
+   only name difference is light normalization, you may apply it. If the proposed name
+   would add/remove/swap substantive name tokens, do not write it automatically — batch
+   it for human approval. If no new info, update last_checked and skip. e. Not a saved
+   contact? Cross-reference the phone number on other platforms (especially
+   `wacli contacts search <number>`) f. Found info (cross-reference match, profile name,
+   or conversation clues)? Spawn the work tier with everything you gathered. It verifies
+   and writes the contact. g. No match anywhere? Spawn the work tier with full
+   conversation context for detective work.
 6. After each contact, upsert into processed.db with the outcome status and timestamp
 7. Notify your human with a batch summary of what was added and what needs their input
 8. If unprocessed contacts remain beyond the 10-per-run cap, note the count in the log
@@ -308,17 +315,19 @@ sessions_spawn:
 Each platform has its own concept of "saved name" vs "profile name." The general rule:
 
 1. **Your human's saved name wins by default** — they chose it for a reason
-2. **BUT if the profile name is more complete, prefer it** — and flag it as enrichment
-3. **"More complete" means:** has a last name when the saved name is first-only, same
-   first name (so clearly the same person, just more info)
-4. **If names differ significantly** (not just completeness), keep your human's but note
-   the discrepancy
+2. **Automatic writes are cosmetic only** — fix case, spacing, punctuation, or remove
+   decorative emoji only when the canonical name tokens are otherwise identical
+3. **Any substantive rename requires explicit human approval** — adding/removing a last
+   name, swapping to a nickname, changing first-name spelling, or replacing one name
+   with another all count as substantive
+4. **If names differ significantly, do not write** — keep your human's saved name,
+   surface the discrepancy, and ask
 
 Examples:
 
-- Saved "Alex", profile "Alex Martinez" — enrichment: suggest updating to full name
+- Saved "Alex", profile "Alex Martinez" — do not auto-update, ask first
 - Saved "Brigitte Huff", profile "Brigitte" — keep saved (more complete)
-- Saved "Sarah Kraut", profile "sarah kraut" — keep saved (same info, cleaner)
+- Saved "Sarah Kraut", profile "sarah kraut" — normalization only, safe to clean
 - No saved name, profile "natalie adele" — use "Natalie Adele" (title case)
 
 When suggesting a contact addition or update, always provide both names if they differ
@@ -362,9 +371,10 @@ Batch your findings into a single message. Don't spam one-by-one. Format:
 - Marcus Rodriguez — added email marcus@example.com (he mentioned it in your WhatsApp
   conversation)
 
-**Name enrichment:**
+**Name review needed:**
 
-- Alex — their WhatsApp profile has "Alex Martinez." Want me to update the contact?
+- Alex — their WhatsApp profile has "Alex Martinez." Want me to rename the existing
+  contact? I did not change it automatically.
 
 **Businesses (skipped):**
 

--- a/workflows/contact-steward/AGENT.md
+++ b/workflows/contact-steward/AGENT.md
@@ -266,14 +266,14 @@ Before first scan, check `PRAGMA user_version`:
    and no new messages since last_checked → skip. c. If found with status `error` →
    treat as new, retry (counts toward cap). d. Is the other party a saved contact on
    this platform? Check for enrichment (new messages with contact-relevant info). If the
-   only name difference is light normalization, you may apply it. If the proposed name
-   would add/remove/swap substantive name tokens, do not write it automatically — batch
-   it for human approval. If no new info, update last_checked and skip. e. Not a saved
-   contact? Cross-reference the phone number on other platforms (especially
-   `wacli contacts search <number>`) f. Found info (cross-reference match, profile name,
-   or conversation clues)? Spawn the work tier with everything you gathered. It verifies
-   and writes the contact. g. No match anywhere? Spawn the work tier with full
-   conversation context for detective work.
+   only name difference is light normalization, spawn the work tier to apply it —
+   scanner never writes. If the proposed name would add/remove/swap substantive name
+   tokens, do not write it automatically — batch it for human approval. If no new info,
+   update last_checked and skip. e. Not a saved contact? Cross-reference the phone
+   number on other platforms (especially `wacli contacts search <number>`) f. Found info
+   (cross-reference match, profile name, or conversation clues)? Spawn the work tier
+   with everything you gathered. It verifies and writes the contact. g. No match
+   anywhere? Spawn the work tier with full conversation context for detective work.
 6. After each contact, upsert into processed.db with the outcome status and timestamp
 7. Notify your human with a batch summary of what was added and what needs their input
 8. If unprocessed contacts remain beyond the 10-per-run cap, note the count in the log

--- a/workflows/contact-steward/classifier.md
+++ b/workflows/contact-steward/classifier.md
@@ -92,10 +92,14 @@ Pull everything you can:
 
 Use the name resolution rules from the platform guide:
 
-- If they have a profile/push name, that's what they want to be known as — prefer it
+- If they have a profile/push name, that's what they want to be known as for **new**
+  contacts
 - Strip decorative emoji for the formal contact name, but note the original
-- If your human has already saved them with a different name, keep theirs unless the
-  profile name is more complete (adds a last name to a first-name-only entry)
+- If your human has already saved them with a different name, do **not** fully rename
+  the contact unless the human explicitly approves it
+- The only automatic update allowed for an existing saved contact is light
+  normalization, where the canonical name tokens stay the same and you are only fixing
+  case, spacing, punctuation, or decorative emoji
 - Title-case names that come in all-lowercase or all-caps
 
 ### Add the Contact
@@ -105,6 +109,10 @@ platform manages its own contacts — WhatsApp via `wacli`, Quo via `quo`, iMess
 Apple Contacts. Read the relevant platform guide in `platforms/` for the correct
 commands.
 
+For an **existing saved** contact, a substantive rename is approval-gated. If the new
+name changes the canonical tokens (for example Alex -> Alex Martinez, Sarah -> Sally, or
+Thomas -> Julianna), do not write it. Return `ask_human` instead.
+
 **Do NOT cross-update.** If you find an unknown WhatsApp contact and discover their name
 via Apple Contacts or Quo, use that info to add them in WhatsApp — but don't touch the
 other platforms' contact databases. Cross-referencing for lookup is fine; cross-writing
@@ -113,11 +121,19 @@ is not.
 ### Handle Uncertainty
 
 **High confidence** (they said their name, clear context, or profile name is a
-recognizable full name): — Add the contact. Report what you added.
+recognizable full name):
+
+- If this is a **new** contact, add it and report what you added.
+- If this is an **existing saved** contact and the change is normalization-only, update
+  it.
+- If this is an **existing saved** contact and the change is a substantive rename, do
+  not write. Ask the human.
 
 **Medium confidence** (profile name exists but could be a nickname, or name comes from a
-group chat mention): — Add the contact with what you have. Note the uncertainty: "Added
-Marcus Rodriguez based on WhatsApp profile name. Let me know if the name is different."
+group chat mention):
+
+- For a **new** contact, add it with what you have and note the uncertainty.
+- For an **existing saved** contact, do not rename it. Ask the human.
 
 **Low confidence** (no name anywhere, only contextual clues): — Don't add. Report:
 "You've been texting +1-555-1234 — they mentioned [clue]. Do you know who this is?"

--- a/workflows/contact-steward/platforms/whatsapp.md
+++ b/workflows/contact-steward/platforms/whatsapp.md
@@ -229,8 +229,8 @@ contact is cosmetic normalization where the canonical name tokens are unchanged.
    only -> **unsaved contact, process it** f. No entry at all -> **unknown contact,
    process it**
 7. If saved + no enrichment: skip
-8. If saved + normalization-only difference: you may normalize, or surface it in the
-   batch summary if you want confirmation
+8. If saved + normalization-only difference: spawn the work tier to apply it — scanner
+   never writes
 9. If saved + substantive name difference: do not write automatically, ask the human
 10. If unsaved: cross-reference on other platforms, then spawn the work tier if still
     unresolved

--- a/workflows/contact-steward/platforms/whatsapp.md
+++ b/workflows/contact-steward/platforms/whatsapp.md
@@ -146,12 +146,18 @@ notifications, or suggesting contact additions), use this priority:
 ### For Saved Contacts (full_name exists)
 
 1. **Default to `full_name`** — this is what your human chose to save
-2. **BUT if `push_name` is more complete, prefer it:**
-   - `full_name` is one word, `push_name` has two+ words with the same first name
-   - Example: `full_name` = "Alex", `push_name` = "Alex Martinez" -> use "Alex Martinez"
-   - This is an **enrichment opportunity** — suggest updating the contact
-3. **If they differ significantly** (different names entirely), use `full_name` but note
-   the discrepancy — your human may have intentionally named them differently
+2. **Automatic updates are cosmetic only:**
+   - Safe examples: case cleanup, spacing cleanup, punctuation cleanup, decorative emoji
+     removal
+   - The canonical name tokens must remain the same after normalization
+   - Example: `full_name` = "Sarah Kraut", `push_name` = "sarah kraut" -> safe
+     normalization
+3. **Any substantive rename requires explicit human approval:**
+   - Adding/removing a last name, switching to a nickname, changing first-name spelling,
+     or replacing one name with another all count as substantive
+   - Example: `full_name` = "Alex", `push_name` = "Alex Martinez" -> ask first
+4. **If they differ significantly**, use `full_name`, note the discrepancy, and do not
+   write automatically
 
 ### For Unsaved Contacts (no full_name)
 
@@ -167,20 +173,20 @@ notifications, or suggesting contact additions), use this priority:
 2. Flag as business -> skip per workflow rules
 3. Log in `processed.db` with any human contact name found in conversation
 
-### "More Complete" Check
+### Normalization vs. Rename Check
 
-A name A is more complete than name B when:
-
-- A has more name parts (first + last vs. first only)
-- A's first name/word matches B (so it's the same person, just more detail)
-- After stripping emoji and normalizing case
+Treat a change as **normalization-only** when the name is the same person string after
+stripping emoji, normalizing case, and collapsing whitespace/punctuation differences. If
+the token set changes, it is a rename and needs approval.
 
 Example comparisons:
 
-- "Alex Martinez" > "Alex" (more complete, same person) -> enrichment
-- "Seth Gordon" vs "Seth" (more complete) -> use Seth Gordon
-- "natalie adele" vs "Natalie" -> push_name is more complete
-- "Brigitte" vs "Brigitte Huff" -> full_name is more complete (keep it)
+- "Sarah Kraut" vs "sarah kraut" -> normalization-only
+- "Oaxana Sri" vs "✨ Oaxana Sri ✨" -> normalization-only
+- "Alex Martinez" vs "Alex" -> rename, ask first
+- "Seth Gordon" vs "Seth" -> rename, ask first
+- "Thomas Owen" vs "Julianna Scruggs" -> different identity, never auto-write
+- "Brigitte" vs "Brigitte Huff" -> rename, ask first
 
 ---
 
@@ -199,6 +205,9 @@ wacli contacts tags add "<JID>" "<tag>"
 
 Setting an alias effectively "saves" the contact in WhatsApp with the name you choose.
 This is the correct action for unknown contacts — set their alias to the resolved name.
+Do **not** use alias writes to fully rename an already-saved contact unless your human
+explicitly approved that rename. The only safe automatic write for an existing saved
+contact is cosmetic normalization where the canonical name tokens are unchanged.
 
 ---
 
@@ -220,9 +229,11 @@ This is the correct action for unknown contacts — set their alias to the resol
    only -> **unsaved contact, process it** f. No entry at all -> **unknown contact,
    process it**
 7. If saved + no enrichment: skip
-8. If saved + enrichment (push_name more complete than full_name): flag for update
-9. If unsaved: cross-reference on other platforms, then spawn the work tier if still
-   unresolved
+8. If saved + normalization-only difference: you may normalize, or surface it in the
+   batch summary if you want confirmation
+9. If saved + substantive name difference: do not write automatically, ask the human
+10. If unsaved: cross-reference on other platforms, then spawn the work tier if still
+    unresolved
 
 ### Batch SQL for Efficiency
 


### PR DESCRIPTION
## Summary

Tightens contact-steward's rename policy so existing saved contacts aren't silently overwritten by WhatsApp push names (or any other profile source).

- **Existing saved contacts are sticky.** Automatic writes are limited to cosmetic normalization — case, spacing, punctuation, decorative emoji — where the canonical name tokens are unchanged.
- **Substantive renames are approval-gated.** Adding/removing a last name, switching to a nickname, changing spelling, or replacing one name with another all require explicit human approval (`ask_human`).
- **New contacts are unchanged** — profile/push names are still the preferred source when there's no saved name to protect.
- Renames the WhatsApp platform guide's "More Complete Check" to "Normalization vs. Rename Check" to match the new model.
- Bumps `contact-steward` version 0.2.0 → 0.2.1.

## Why

Enrichment and rename look similar from the agent's perspective but are very different for the human: enrichment is reversible cosmetic polish, rename changes identity. Conflating them meant saved contacts could be silently overwritten when profile names drifted or when two people ended up on the same number.

## Files

- `workflows/contact-steward/AGENT.md` — trust rule + enrichment step rewritten
- `workflows/contact-steward/classifier.md` — uncertainty tiers split by new vs. existing
- `workflows/contact-steward/platforms/whatsapp.md` — name priority + normalization check rewritten

## Test plan

- [ ] Deploy to Cora and run Contact Steward — WhatsApp on next scheduled run (7am/5pm CT)
- [ ] Verify existing saved contacts with differing push_names are surfaced for approval rather than silently renamed
- [ ] Verify cosmetic-only differences (case, emoji) still auto-normalize
- [ ] Verify new unsaved contacts still get added using push_name as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)