### PR TITLE
fix(contact-steward): block identifier hijacks on saved contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ invoke), workflows maintain state, learn your preferences, and manage themselves
 | **email-steward**     | Triage inbox — archive noise, label, alert on important                    | 0.3.0   |
 | **task-steward**      | Classify work, create tasks, spawn sub-agents, QA results                  | 0.1.0   |
 | **calendar-steward**  | Daily briefing — travel time, meeting prep, conflict detection             | 0.1.0   |
-| **contact-steward**   | Detect unknown contacts across platforms, classify & organize              | 0.2.1   |
+| **contact-steward**   | Detect unknown contacts across platforms, classify & organize              | 0.2.2   |
 | **security-sentinel** | Threat intelligence research & fleet exposure mapping                      | 0.1.0   |
 | **cron-healthcheck**  | Detect broken cron jobs, auto-remediate, escalate failures                 | 0.1.0   |
 | **learning-loop**     | Self-improvement — capture corrections, detect patterns, promote learnings | 0.1.0   |

--- a/workflows/contact-steward/AGENT.md
+++ b/workflows/contact-steward/AGENT.md
@@ -376,8 +376,7 @@ Batch your findings into a single message. Don't spam one-by-one. Format:
 
 **Updated:**
 
-- Marcus Rodriguez — added email marcus@example.com (he mentioned it in your WhatsApp
-  conversation)
+- Alex Martinez — normalized name spacing (was "Alex Martinez" with double space)
 
 **Name review needed:**
 
@@ -386,7 +385,7 @@ Batch your findings into a single message. Don't spam one-by-one. Format:
 
 **Identity conflict review needed:**
 
-- Julianna Scruggs — this thread surfaced a new phone number that is not already on her
+- <Contact Name> — this thread surfaced a new phone number that is not already on their
   saved contact. I did not attach it automatically because phone numbers are treated as
   identity anchors and need human confirmation.
 

--- a/workflows/contact-steward/AGENT.md
+++ b/workflows/contact-steward/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: contact-steward
-version: 0.2.1
+version: 0.2.2
 description:
   Manages contacts across messaging platforms — detects unidentified contacts your human
   is actively engaging with, classifies them, and adds them to the appropriate platform
@@ -21,6 +21,11 @@ Apple Contacts. See each platform guide for the correct commands.
 contact unless your human explicitly approves that exact rename. Automatic updates are
 limited to light normalization only (case, spacing, punctuation, or emoji cleanup) when
 the canonical name tokens are unchanged.
+
+**Identity-anchor rule:** phone numbers, email addresses, and other routing identifiers
+are higher-trust than profile names. Never attach a new phone number, email address, or
+other identifier to an existing saved contact automatically. If the identifier is not
+already on that exact contact, stop and ask the human, even when the name looks right.
 
 ## Prerequisites
 
@@ -317,10 +322,13 @@ Each platform has its own concept of "saved name" vs "profile name." The general
 1. **Your human's saved name wins by default** — they chose it for a reason
 2. **Automatic writes are cosmetic only** — fix case, spacing, punctuation, or remove
    decorative emoji only when the canonical name tokens are otherwise identical
-3. **Any substantive rename requires explicit human approval** — adding/removing a last
+3. **Never auto-attach a new identifier to an existing saved contact** — new phone
+   numbers, email addresses, handles, or addresses always require explicit human
+   approval, even if the proposed name appears to match
+4. **Any substantive rename requires explicit human approval** — adding/removing a last
    name, swapping to a nickname, changing first-name spelling, or replacing one name
    with another all count as substantive
-4. **If names differ significantly, do not write** — keep your human's saved name,
+5. **If names differ significantly, do not write** — keep your human's saved name,
    surface the discrepancy, and ask
 
 Examples:
@@ -375,6 +383,12 @@ Batch your findings into a single message. Don't spam one-by-one. Format:
 
 - Alex — their WhatsApp profile has "Alex Martinez." Want me to rename the existing
   contact? I did not change it automatically.
+
+**Identity conflict review needed:**
+
+- Julianna Scruggs — this thread surfaced a new phone number that is not already on her
+  saved contact. I did not attach it automatically because phone numbers are treated as
+  identity anchors and need human confirmation.
 
 **Businesses (skipped):**
 

--- a/workflows/contact-steward/classifier.md
+++ b/workflows/contact-steward/classifier.md
@@ -100,6 +100,9 @@ Use the name resolution rules from the platform guide:
 - The only automatic update allowed for an existing saved contact is light
   normalization, where the canonical name tokens stay the same and you are only fixing
   case, spacing, punctuation, or decorative emoji
+- Phone numbers, email addresses, and other routing identifiers are identity anchors. Do
+  **not** attach a new identifier to an existing saved contact automatically, even if
+  the proposed name looks right
 - Title-case names that come in all-lowercase or all-caps
 
 ### Add the Contact
@@ -112,6 +115,10 @@ commands.
 For an **existing saved** contact, a substantive rename is approval-gated. If the new
 name changes the canonical tokens (for example Alex -> Alex Martinez, Sarah -> Sally, or
 Thomas -> Julianna), do not write it. Return `ask_human` instead.
+
+For an **existing saved** contact, adding a new phone number, email address, or other
+routing identifier is also approval-gated. If that identifier is not already present on
+that exact contact, return `ask_human` instead of writing it.
 
 **Do NOT cross-update.** If you find an unknown WhatsApp contact and discover their name
 via Apple Contacts or Quo, use that info to add them in WhatsApp — but don't touch the
@@ -126,6 +133,8 @@ recognizable full name):
 - If this is a **new** contact, add it and report what you added.
 - If this is an **existing saved** contact and the change is normalization-only, update
   it.
+- If this is an **existing saved** contact and the change introduces any new phone,
+  email, or other routing identifier, do not write. Ask the human.
 - If this is an **existing saved** contact and the change is a substantive rename, do
   not write. Ask the human.
 
@@ -133,7 +142,8 @@ recognizable full name):
 group chat mention):
 
 - For a **new** contact, add it with what you have and note the uncertainty.
-- For an **existing saved** contact, do not rename it. Ask the human.
+- For an **existing saved** contact, do not rename it or attach new identifiers. Ask the
+  human.
 
 **Low confidence** (no name anywhere, only contextual clues): — Don't add. Report:
 "You've been texting +1-555-1234 — they mentioned [clue]. Do you know who this is?"

--- a/workflows/contact-steward/platforms/imessage.md
+++ b/workflows/contact-steward/platforms/imessage.md
@@ -90,6 +90,11 @@ tell application "Contacts"
 end tell'
 ```
 
+Note: Apple Contacts may store numbers with different formatting (spaces, parentheses,
+dashes). `imsg` reports sender numbers in E.164 format (`+1XXXXXXXXXX`), but an existing
+contact entry might be stored as `+1 (555) 123-4567`. If the exact match returns empty,
+also try a digit-only comparison before concluding there is no conflict.
+
 If this returns any name other than the intended contact, treat it as `ask_human`.
 
 ### Adding Contacts to Apple Contacts

--- a/workflows/contact-steward/platforms/imessage.md
+++ b/workflows/contact-steward/platforms/imessage.md
@@ -61,17 +61,47 @@ end tell'
 ```
 
 **Performance note:** Searching by name is fast. Iterating all contacts to search by
-phone number is extremely slow (large contact lists). Prefer name-based lookups.
+phone number is extremely slow (large contact lists). Prefer name-based lookups for the
+initial saved/not-saved check.
 
 To check by phone number efficiently, cross-reference the number against
 `wacli contacts search "<number>"` first to get a name, then search Apple Contacts by
 that name.
+
+**Before any write, do a phone-number conflict check (mandatory):** if the phone number
+already exists on any Apple Contact under a different name, stop and ask the human. Do
+not add the number to another card and do not auto-merge identities. A wrong phone
+number on the wrong person is worse than a missed add.
+
+Example conflict check:
+
+```bash
+osascript -e '
+tell application "Contacts"
+    set outList to {}
+    repeat with p in every person
+        repeat with ph in phones of p
+            if value of ph is "<+1XXXXXXXXXX>" then
+                set end of outList to name of p
+            end if
+        end repeat
+    end repeat
+    return outList
+end tell'
+```
+
+If this returns any name other than the intended contact, treat it as `ask_human`.
 
 ### Adding Contacts to Apple Contacts
 
 **iMessage contacts ARE Apple Contacts** — this is the correct place to add contacts for
 this platform. Use AppleScript to manage them directly. Do NOT add contacts to WhatsApp
 or Quo from here — cross-referencing for lookup is fine, cross-writing is not.
+
+**Existing-contact rule:** For a contact that is already saved in Apple Contacts, the
+only automatic mutation allowed is cosmetic name normalization where the canonical name
+is unchanged. Do **not** auto-attach a new phone number, email address, or other routing
+identifier to an existing saved contact. That always requires human approval.
 
 **Input sanitization (MANDATORY — security critical):** Names come from WhatsApp
 profiles, conversation text, and other untrusted sources. A malicious profile name like
@@ -139,6 +169,10 @@ tell application "Contacts"
 end tell'
 ```
 
+Only use enrichment writes like email/address updates after explicit human approval for
+that exact existing contact. Do not treat a guessed match as permission to attach new
+identifiers.
+
 You can also add email, address, etc:
 
 ```bash
@@ -205,7 +239,8 @@ iMessage gets more spam than WhatsApp. Common patterns to skip:
 6. Cross-reference (if WhatsApp is configured): `wacli contacts search "<number>"` to
    get a name. If WhatsApp is not available, skip to step 7b.
 7. a. If name found via WhatsApp: check Apple Contacts by name. If missing, spawn the
-   work tier with the name and number to verify and add to Apple Contacts. b. If no name
-   from cross-reference (or WhatsApp not configured): spawn the work tier with the full
-   conversation — it will look for self-introductions, context clues, and check other
-   available platforms.
+   work tier with the name and number to verify and add to Apple Contacts. Before any
+   eventual write, the work tier must run the phone-number conflict check above. b. If
+   no name from cross-reference (or WhatsApp not configured): spawn the work tier with
+   the full conversation — it will look for self-introductions, context clues, and check
+   other available platforms.


### PR DESCRIPTION
## Summary
- treat phone numbers, emails, and other routing identifiers as identity anchors for saved contacts
- require human approval before attaching any new identifier to an existing saved contact
- add an iMessage Apple Contacts phone-conflict preflight so a number already attached elsewhere becomes ask_human instead of an automatic write

## Why
A documented Contact Steward incident auto-corrected +17079719122 from "Havan" to "Starielle", which shows the workflow could still perform trust-sensitive identity replacements. Separately, steward history kept +15129479757 mapped to Julianna Scruggs and +16088079097 mapped to Thomas Owen, which makes the Thomas/Julianna scare look like the same risk class: a stronger identity anchor can get attached to the wrong saved contact if the workflow treats it as enrichment.

This PR makes the workflow more conservative for fleet rollout: saved-contact automation is limited to cosmetic normalization only, and new identifiers on existing contacts always stop for human review.

## Validation
- reviewed steward history/logs showing +15129479757 -> Julianna Scruggs and +16088079097 -> Thomas Owen remained distinct in steward artifacts
- verified current Apple Contacts readback for Julianna, Thomas, Havan, and Starielle
- reviewed the scoped diff for AGENT.md, classifier.md, platforms/imessage.md, and README.md
- commit passed repo pre-commit hooks, including Prettier
