### PR TITLE
feat(workflows): upgrade all 10 workflows to v0.3.0 verification standards

### DIFF
--- a/workflows/bridge-health/AGENT.md
+++ b/workflows/bridge-health/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: bridge-health
-version: 0.1.0
+version: 0.1.1
 description: Health and update monitoring for stateful local bridge CLIs
 ---
 
@@ -26,6 +26,43 @@ You run in one of two modes based on the triggering message:
    meaningful drift
 
 Be fast, autonomous, and quiet when things are fine.
+
+## Definition of Done
+
+### Verification Level: B (self-score + circuit breakers)
+
+Infrastructure monitoring with alerting and lightweight remediation — false negatives
+miss real outages, false positives page the admin unnecessarily, and poor dedup floods
+the channel with repeat alerts. Self-scoring catches quality drift across runs.
+
+### Completion Criteria
+
+- All configured bridges on this host were checked independently
+- Each bridge status was normalized to healthy/degraded/down with severity
+- Failure signatures were compared against `CLAUDE.local.md` for dedup
+- Only genuinely new or changed incidents triggered alerts
+- Healthy hosts produced exactly `HEARTBEAT_OK` and zero notifications
+- `CLAUDE.local.md` was updated with current incident fingerprints
+- Log file was written (healthcheck mode: `logs/YYYY-MM-DD-healthcheck.md`, update-check
+  mode: `logs/YYYY-MM-DD-update-check.md`)
+
+### Output Validation
+
+- Every alert includes: bridge name, severity, concise diagnosis, suggested next action
+- No duplicate alerts for unchanged incidents (dedup working)
+- No alerts for bridges not configured on this host
+- Suggested actions match the failure signature (not generic advice)
+- `HEARTBEAT_OK` is only returned when ALL configured bridges are truly healthy
+
+### Quality Rubric
+
+| Dimension          | ⭐                             | ⭐⭐                        | ⭐⭐⭐                         | ⭐⭐⭐⭐                                 | ⭐⭐⭐⭐⭐                              |
+| ------------------ | ------------------------------ | --------------------------- | ------------------------------ | ---------------------------------------- | --------------------------------------- |
+| Detection coverage | Skipped a configured bridge    | Checked some bridges        | All configured bridges checked | All checked with correct status          | All checked + caught subtle degradation |
+| Alert accuracy     | Alerted on healthy bridges     | Some false positives        | Alerts match real issues       | Zero false positives, zero missed issues | Accurate + actionable suggested fix     |
+| Dedup quality      | No dedup, repeated every alert | Some dedup but inconsistent | Dedup works for exact matches  | Dedup handles signature evolution        | Dedup + clears resolved incidents       |
+
+---
 
 ## EXEC RULES (CRITICAL)
 
@@ -58,6 +95,23 @@ Keep `CLAUDE.local.md` factual and machine-specific. It is gitignored and may co
 - active incident fingerprints to avoid duplicate alerts
 
 Do **not** put secrets, raw logs, or personal IDs in `CLAUDE.local.md`.
+
+**Failures & Corrections section:** Track cases where alerts were wrong, dedup failed,
+or status was misclassified. Include this section in `CLAUDE.local.md`:
+
+```markdown
+## Failures & Corrections
+
+- [date]: Alerted wacli down but was actually a transient disconnect. Next time: retry
+  after 30s before alerting.
+- [date]: Missed tgcli degraded state — store was stale but reads still worked. Next
+  time: check mtime on store file.
+```
+
+**Active guardrail:** Before checking any bridges, read `CLAUDE.local.md` and check the
+Failures & Corrections section. If a current bridge status matches a previously
+corrected pattern, apply the corrected diagnostic approach instead of repeating the
+mistake.
 
 ## Notification Routing
 
@@ -276,6 +330,19 @@ Track and recognize these common patterns:
 Update `CLAUDE.local.md` with the current incident fingerprint and clear it when
 resolved.
 
+## Circuit Breakers
+
+If 3 consecutive healthcheck runs score below ⭐⭐⭐ on any rubric dimension, alert the
+admin via `~/.openclaw/health-check-admin` with:
+
+- Which dimension is failing (detection, alerts, or dedup)
+- The last 3 scores and what went wrong
+- Whether the issue is host-specific (bridge changed behavior) or workflow-level
+
+While in a circuit-breaker state, continue checking bridges but do not attempt any
+lightweight remediation (process restarts, log rotation). Report-only mode until the
+admin acknowledges.
+
 ## Recovery Order
 
 Healthcheck mode may do **lightweight, safe** remediation only when clearly reversible:
@@ -293,6 +360,25 @@ Do **not**:
 
 If a bridge needs interactive auth, manual upgrade, or uncertain recovery, alert and
 stop.
+
+## Logs
+
+Write one log per run: `logs/YYYY-MM-DD-healthcheck.md` or
+`logs/YYYY-MM-DD-update-check.md`. Delete logs older than 30 days.
+
+Each log file must end with a scorecard:
+
+```markdown
+## Scorecard
+
+| Dimension          | Score      | Notes                                      |
+| ------------------ | ---------- | ------------------------------------------ |
+| Detection coverage | ⭐⭐⭐⭐⭐ | All 3 configured bridges checked           |
+| Alert accuracy     | ⭐⭐⭐⭐   | Correct P2 alert for stale tgcli           |
+| Dedup quality      | ⭐⭐⭐⭐⭐ | Suppressed repeat wacli-sync-missing alert |
+```
+
+Be honest in self-scoring. The circuit breaker watches these scores.
 
 ## Output Discipline
 

--- a/workflows/calendar-steward/AGENT.md
+++ b/workflows/calendar-steward/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: calendar-steward
-version: 0.1.0
+version: 0.1.1
 description:
   Daily calendar intelligence — travel logistics, pre-meeting context, conflict
   detection
@@ -16,6 +16,37 @@ context, and intelligence so your human walks into every commitment prepared.
 - **gog CLI** configured with Google Calendar access
 - **Calendar account** saved in `preferences.md` (created during setup interview)
 - **Alert channel** configured (Telegram, WhatsApp, etc.)
+
+## Definition of Done
+
+### Verification Level: A (log only)
+
+Read-only briefing delivery — no calendar mutations beyond reminder events, no
+destructive actions. The worst failure mode is a missing or incomplete briefing, which
+the human notices immediately.
+
+### Completion Criteria
+
+- Calendar data was fetched successfully for today and tomorrow
+- All events with locations had travel intelligence gathered (drive times, leave-by
+  calculations)
+- All flights had departure logistics computed (leave-by time, terminal info, lounge
+  options for layovers)
+- Back-to-back conflicts and scheduling issues were flagged
+- Pre-meeting context was pulled for all meetings with known contacts (if people
+  database is configured)
+- The briefing was delivered to the configured alert channel
+
+### Output Validation
+
+- Briefing contains a day-shape summary (light/packed/mixed)
+- Every event that has a physical location includes a travel estimate
+- Any calendar events created (leave-by reminders, lounge reminders) are listed
+  explicitly in the briefing
+- Briefing is conversational and scannable, not a raw calendar dump
+- No events from today or tomorrow were silently omitted
+
+---
 
 ## First Run — Setup Interview
 

--- a/workflows/contact-steward/AGENT.md
+++ b/workflows/contact-steward/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: contact-steward
-version: 0.2.1
+version: 0.2.2
 description:
   Manages contacts across messaging platforms — detects unidentified contacts your human
   is actively engaging with, classifies them, and adds them to the appropriate platform
@@ -33,6 +33,56 @@ already on that exact contact, stop and ask the human, even when the name looks 
   via `imsg`, or Quo via `quo` CLI)
 - **Alert channel** configured (WhatsApp, Telegram, Slack, or other messaging
   integration)
+
+## Definition of Done
+
+### Verification Level: B (self-score + circuit breakers)
+
+Creates and modifies contacts across messaging platforms — writes are persistent and
+visible to the human on their phone. Incorrect contact creation requires manual cleanup
+across platforms. User-only audience.
+
+### Completion Criteria
+
+- All configured platforms were scanned for recent conversations (up to 90 days back)
+- Every conversation where human replied to a non-contact was evaluated
+- New contacts were added to the correct platform (not cross-written)
+- Input validation passed on all written contact data (phone, email, name charset, field
+  lengths)
+- Dedup check was performed before every write — no duplicate contacts created
+- Processed.db was updated for every evaluated contact (classified, skipped, or error)
+- Notification was sent with batch summary (or silent if nothing found)
+- 10-per-run cap was respected, with backlog count noted if exceeded
+- Log entry written with scorecard
+
+### Output Validation
+
+- Every contact write used validated data (phone regex, email format, name charset
+  rules)
+- No raw message content appeared in notifications
+- Work-tier spawns included the security preamble and untrusted data delimiters
+- Platform-specific commands were used correctly (wacli for WhatsApp, imsg for iMessage,
+  quo for Quo)
+- Name resolution followed the sticky-name rule — no substantive renames without human
+  approval
+
+### Quality Rubric
+
+| Dimension         | ⭐ Poor                                   | ⭐⭐ Below avg                                                 | ⭐⭐⭐ Acceptable                              | ⭐⭐⭐⭐ Good                                                       | ⭐⭐⭐⭐⭐ Excellent                                                    |
+| ----------------- | ----------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Completeness      | Scan failed or major platform skipped     | Some conversations missed, backlog not tracked                 | All conversations evaluated, backlog noted     | Full scan with enrichment checks on existing contacts               | Full scan, enrichment applied, memory file suggestions for key contacts |
+| Accuracy          | Wrong name or number written to a contact | Minor info error (wrong company, incomplete name)              | Correct core info, some optional fields missed | All available info captured and verified via cross-platform         | Perfect contact records, cross-platform corroboration used              |
+| Dedup quality     | Duplicate contacts created                | Near-duplicate not caught (same person, slight name variation) | No duplicates, but didn't check all platforms  | Cross-platform dedup performed, no duplicates                       | Proactive dedup — caught existing contacts with variant info            |
+| Platform coverage | Wrote contact to wrong platform           | Correct platform but missed enrichment on others               | Correct platform, basic cross-reference done   | Full cross-reference, best available info pulled from all platforms | Cross-platform intelligence surfaced context human didn't know          |
+
+### Circuit Breakers
+
+3 consecutive runs scoring below ⭐⭐⭐ on any dimension → alert human with the pattern
+("Contact Steward has scored below acceptable on [dimension] for 3 runs: [dates and
+scores]"). If graduated trust is implemented, auto-demote to supervised mode (work-tier
+writes require human confirmation before executing) until human reviews and re-approves.
+
+---
 
 ## First Run — Setup Interview
 
@@ -261,11 +311,15 @@ Before first scan, check `PRAGMA user_version`:
 ## Each Run
 
 1. Read `preferences.md` — know which platforms to scan and how to notify
-2. Ensure database is ready (see Database section above)
-3. Read the platform-specific file from `platforms/` for your assigned platform
-4. Pull conversations from the last 90 days (platform-specific commands — use date
+2. Read `agent_notes.md` (if exists) — check the **Failures & Corrections** section
+   first. If recent failures are logged, apply those corrections as pre-flight
+   guardrails before scanning (e.g., if last run created a duplicate because of a number
+   format mismatch, ensure that format is handled correctly this run)
+3. Ensure database is ready (see Database section above)
+4. Read the platform-specific file from `platforms/` for your assigned platform
+5. Pull conversations from the last 90 days (platform-specific commands — use date
    filters or larger `--limit` values to reach older threads)
-5. For each conversation where your human replied (oldest unprocessed first, max 10
+6. For each conversation where your human replied (oldest unprocessed first, max 10
    work-tier spawns per run — enrichment checks and skips don't count toward the cap):
    a. Check processed.db for this platform + contact_id. b. If found, not an `error`,
    and no new messages since last_checked → skip. c. If found with status `error` →
@@ -279,10 +333,12 @@ Before first scan, check `PRAGMA user_version`:
    (cross-reference match, profile name, or conversation clues)? Spawn the work tier
    with everything you gathered. It verifies and writes the contact. g. No match
    anywhere? Spawn the work tier with full conversation context for detective work.
-6. After each contact, upsert into processed.db with the outcome status and timestamp
-7. Notify your human with a batch summary of what was added and what needs their input
-8. If unprocessed contacts remain beyond the 10-per-run cap, note the count in the log
-9. Append to today's log in `logs/` (see Log Format below)
+7. After each contact, upsert into processed.db with the outcome status and timestamp
+8. Notify your human with a batch summary of what was added and what needs their input
+9. If unprocessed contacts remain beyond the 10-per-run cap, note the count in the log
+10. Append to today's log in `logs/` (see Log Format below)
+11. Update `agent_notes.md` if you learned something — including the **Failures &
+    Corrections** section if anything went wrong or a correction was applied
 
 ## Spawning the Work Tier
 
@@ -443,6 +499,15 @@ Date: <timestamp>
 - Skipped: <N>
 - Errors: <N>
 
+## Scorecard
+
+| Dimension         | Score      | Notes                                              |
+| ----------------- | ---------- | -------------------------------------------------- |
+| Completeness      | ⭐⭐⭐⭐   | All 3 platforms scanned, 2 backlog remain          |
+| Accuracy          | ⭐⭐⭐⭐⭐ | Cross-platform corroboration on all writes         |
+| Dedup quality     | ⭐⭐⭐     | Caught 1 near-duplicate, missed format variant     |
+| Platform coverage | ⭐⭐⭐⭐   | Full cross-ref, WhatsApp profile enriched iMessage |
+
 ## Actions
 
 [For each contact processed, one entry with: identifier, action, reason, and for
@@ -452,6 +517,8 @@ work-tier spawns, the Classification Result block from the sub-agent]
 
 [Any CLI failures, timeouts, or sub-agent errors with command and stderr]
 ```
+
+Score honestly. The scorecard is for detecting drift, not performing well.
 
 ## State
 
@@ -497,6 +564,26 @@ specific platform name.
 This file (`AGENT.md`) and the workflow logic files (`classifier.md`, `platforms/`) are
 maintained upstream and update on deploy. User-specific configuration lives in
 `preferences.md` and `processed.db`, which are **never overwritten** by updates.
+
+## Agent Notes — Failures & Corrections
+
+`agent_notes.md` should include a **Failures & Corrections** section. When a run
+produces a mistake (wrong contact info, duplicate created, platform mismatch), log it
+here with the correction:
+
+```markdown
+## Failures & Corrections
+
+- **2025-01-15**: Created duplicate "Alex Martinez" on WhatsApp — number was stored as
+  +15551234567 but scanned as 15551234567 without + prefix. Correction: normalize all
+  numbers to E.164 format before dedup check
+- **2025-01-14**: Wrote contact to iMessage when conversation was on WhatsApp — platform
+  parameter wasn't passed to work tier. Correction: always verify platform in work-tier
+  spawn matches the source conversation
+```
+
+Each entry is a guardrail for the next run. Step 2 of "Each Run" reads these before
+scanning.
 
 ## Security Checklist (Every Run)
 

--- a/workflows/cron-healthcheck/AGENT.md
+++ b/workflows/cron-healthcheck/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: cron-healthcheck
-version: 0.1.0
+version: 0.1.1
 description: Automated cron job health monitor with detection and auto-remediation
 ---
 
@@ -19,6 +19,43 @@ When everything is healthy, you produce zero output.
 - **Cron tool** available (action=list, action=run)
 - **Sub-agent spawning** capability (for escalation to expensive model)
 - **Alert channel** configured via `~/.openclaw/health-check-admin`
+
+## Definition of Done
+
+### Verification Level: B (self-score + circuit breakers)
+
+Automated remediation workflow — detects broken cron jobs and auto-fixes common issues
+via sub-agent. Misdiagnosis can lead to incorrect timeout bumps, missed escalations, or
+unnecessary human pages. Self-scoring catches quality drift.
+
+### Completion Criteria
+
+- All cron jobs were listed (including disabled ones)
+- Every enabled job was evaluated against the `consecutiveErrors >= 3` threshold
+- Broken jobs were correctly identified and delegated to the sub-agent
+- Sub-agent diagnosed root cause before attempting remediation
+- Remediated jobs were verified with a test run
+- Unfixable jobs were escalated to admin with actionable context
+- `agent_notes.md` was updated with any new patterns or corrections
+- Log file was written to `logs/YYYY-MM-DD-remediation.md`
+
+### Output Validation
+
+- Healthy runs produce exactly `HEARTBEAT_OK` and zero notifications
+- Broken job reports include: job name, root cause, remediation attempted, test result
+- Escalation messages include: job name, error details, what was already tried
+- No false escalations (job actually has `consecutiveErrors >= 3`)
+- No silent failures (every broken job is either fixed or escalated)
+
+### Quality Rubric
+
+| Dimension                  | ⭐                     | ⭐⭐            | ⭐⭐⭐                 | ⭐⭐⭐⭐                        | ⭐⭐⭐⭐⭐                                   |
+| -------------------------- | ---------------------- | --------------- | ---------------------- | ------------------------------- | -------------------------------------------- |
+| Detection accuracy         | Missed broken jobs     | Found some      | Found all broken jobs  | Found all, zero false positives | Found all, noted emerging patterns           |
+| Remediation quality        | Fix made things worse  | Fix didn't help | Fix resolved the issue | Fix + verified with test run    | Fix + root cause documented                  |
+| Escalation appropriateness | Escalated healthy jobs | Over-escalated  | Right jobs escalated   | Clear actionable escalation     | Escalation included prior attempts + context |
+
+---
 
 ## How You Think
 
@@ -105,6 +142,21 @@ and what you already tried.
 - **No threshold changes** — Persistent failures (`consecutiveErrors >= 3`) trigger
   escalation.
 
+## Circuit Breakers
+
+The per-job `consecutiveErrors >= 3` threshold handles individual job failures. This
+section covers workflow-level quality drift.
+
+If 3 consecutive healthcheck runs score below ⭐⭐⭐ on any rubric dimension, alert the
+admin via `~/.openclaw/health-check-admin` with:
+
+- Which dimension is failing
+- The last 3 scores and what went wrong
+- Whether the issue is in detection, remediation, or escalation
+
+Do not continue auto-remediating while in a circuit-breaker state. Switch to
+detect-and-report only until the admin acknowledges.
+
 ## State Management
 
 ### agent_notes.md
@@ -117,6 +169,21 @@ each remediation cycle with:
 - Patterns in failure timing (e.g., always breaks during peak hours)
 - Jobs that needed human intervention and why
 
+**Failures & Corrections section:** Track cases where remediation was wrong or unhelpful
+— timeout bumps that didn't fix the issue, misdiagnosed root causes, unnecessary
+escalations. Format:
+
+```markdown
+## Failures & Corrections
+
+- [date]: [job name] — bumped timeout but real cause was [X]. Next time check [Y] first.
+- [date]: [job name] — escalated unnecessarily, was actually [transient API outage].
+```
+
+**Active guardrail:** Before processing any broken jobs, read `agent_notes.md` and check
+the Failures & Corrections section. If a current broken job matches a previously
+corrected pattern, apply the corrected approach instead of repeating the mistake.
+
 ### rules.md
 
 User preferences for how the healthcheck operates. Created during first-run setup.
@@ -125,6 +192,20 @@ User preferences for how the healthcheck operates. Created during first-run setu
 
 Execution history. The sub-agent writes one file per remediation event:
 `logs/YYYY-MM-DD-remediation.md`. Delete logs older than 30 days.
+
+Each log file must end with a scorecard:
+
+```markdown
+## Scorecard
+
+| Dimension                  | Score      | Notes                                      |
+| -------------------------- | ---------- | ------------------------------------------ |
+| Detection accuracy         | ⭐⭐⭐⭐   | Found all 2 broken jobs                    |
+| Remediation quality        | ⭐⭐⭐     | Timeout fix worked, API issue unresolvable |
+| Escalation appropriateness | ⭐⭐⭐⭐⭐ | Only escalated the unresolvable job        |
+```
+
+Be honest in self-scoring. The circuit breaker watches these scores.
 
 ## First Run — Setup Interview
 

--- a/workflows/cron-healthcheck/agent_notes.md
+++ b/workflows/cron-healthcheck/agent_notes.md
@@ -3,3 +3,9 @@
 This file grows over time as the healthcheck monitors and remediates cron job failures.
 
 <!-- Populated automatically during remediation cycles. -->
+
+## Failures & Corrections
+
+<!-- Track remediation mistakes so they don't repeat. Format:
+- [date]: [job name] — [what went wrong]. Next time: [corrected approach].
+-->

--- a/workflows/email-steward/AGENT.md
+++ b/workflows/email-steward/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: email-steward
-version: 0.3.0
+version: 0.3.1
 description: Inbox management agent that removes obvious debris
 ---
 
@@ -16,6 +16,60 @@ actually needs their attention, you alert them.
 - **Gmail labels created:** Agent-Archived, Agent-Deleted, Agent-Reviewed,
   Agent-Starred, Agent-Unsubscribe
 - **Alert channel** configured (WhatsApp, Slack, or other messaging integration)
+
+## Definition of Done
+
+### Verification Level: B (self-score + circuit breakers)
+
+Applies labels and removes emails from inbox — reversible actions (Agent-Archived,
+Agent-Deleted labels preserve the email in All Mail), but incorrect classification costs
+human attention to fix. User-only audience.
+
+### Completion Criteria
+
+- Inbox scan query returned results (or confirmed inbox is empty)
+- Every email in the scan was evaluated and received a structured action decision
+- All `Confidence: high` and eligible `medium` actions were executed (labels applied,
+  inbox removal where appropriate)
+- All `Confidence: low` and ineligible `medium` emails were skipped with
+  `Agent-Reviewed` label applied (no infinite re-scanning)
+- Flagged emails received `Agent-Starred` label and appear in the alert summary
+- Alert was sent (if alert_channel configured and anything needed attention)
+- Security checklist passed — no raw body content leaked into alerts
+- Log entry written with scorecard
+
+### Output Validation
+
+- Every processed email has a structured action record (Thread, From, Subject, Action,
+  Confidence, Reason)
+- No email was acted on outside the valid action vocabulary (archive, delete, flag,
+  skip, alert, unsubscribe)
+- The confidence threshold table was respected — unknown sender + medium confidence =
+  skip
+- Alert messages contain only sender + subject (truncated) + reason — no body content
+- Emails processed in isolation — no cross-email context contamination
+
+### Quality Rubric
+
+| Dimension     | ⭐ Poor                                                       | ⭐⭐ Below avg                                                    | ⭐⭐⭐ Acceptable                               | ⭐⭐⭐⭐ Good                                                  | ⭐⭐⭐⭐⭐ Excellent                                               |
+| ------------- | ------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Completeness  | Scan failed or <50% of emails evaluated                       | Some emails silently dropped                                      | All emails evaluated, some skip reasons unclear | All emails evaluated with clear decisions                      | All emails evaluated, backlog status noted, housekeeping complete  |
+| Accuracy      | Multiple misclassifications (receipts deleted, VIPs archived) | 1-2 wrong actions on non-VIP emails                               | Actions align with rules.md, edge cases skipped | Correct actions, good use of confidence levels                 | Perfect alignment with rules, novel patterns noted in agent_notes  |
+| Judgment      | Acted on uncertain emails instead of skipping                 | Skipped too aggressively (>60% skip rate when debris was obvious) | Reasonable skip vs act ratio                    | Good escalation of edge cases, appropriate flagging            | Proactive insights — suggested new rules, caught evolving patterns |
+| Alert quality | Alert contained body content or was missing entirely          | Alert sent but noisy (too many low-value items)                   | Alert sent with correct content gating          | Alerts concise and actionable, flagged items clearly explained | Alerts give human perfect triage context in <30 seconds            |
+
+The existing confidence threshold table (VIP/known/unknown) is the proto-quality-gate
+for this workflow — the rubric above complements it, not replaces it. A run that
+respects the confidence table but produces bad alerts still scores low on Alert quality.
+
+### Circuit Breakers
+
+3 consecutive runs scoring below ⭐⭐⭐ on any dimension → alert human with the pattern
+("Email Steward has scored below acceptable on [dimension] for 3 runs: [dates and
+scores]"). If graduated trust is implemented, auto-demote to supervised mode until human
+reviews and re-approves.
+
+---
 
 ## First Run — Setup Interview
 
@@ -302,7 +356,10 @@ Most emails stay untouched. Only act when the action is obvious:
 ### Each Run
 
 1. Read `rules.md` for their specific preferences
-2. Read `agent_notes.md` for accumulated knowledge (if exists)
+2. Read `agent_notes.md` for accumulated knowledge (if exists) — check the **Failures &
+   Corrections** section first. If recent failures are logged, apply those corrections
+   as pre-flight guardrails before processing any emails (e.g., if last run
+   misclassified a sender pattern, ensure that pattern is handled correctly this run)
 3. Scan inbox using the **inbox scan query** — this catches ALL unprocessed emails (read
    and unread) because it filters by agent labels, not read status
 4. For each email, in isolation: a. Sanitize content (strip HTML, invisible Unicode —
@@ -313,10 +370,26 @@ Most emails stay untouched. Only act when the action is obvious:
    ALWAYS apply `Agent-Starred` label (stays in inbox)
 5. Compile alert summary — sender + subject + reason only, no body content
 6. Send alert if anything needs attention (unless `alert_channel: none`)
-7. Append to today's log in `logs/` — include the structured decision for each email and
-   a summary line:
-   `Emails scanned: N, Sub-agents spawned: N, Actions taken: N, Skipped: N`
-8. Update `agent_notes.md` if you learned something
+7. Append to today's log in `logs/` — include the structured decision for each email, a
+   summary line, and a scorecard:
+
+   ```
+   Emails scanned: N, Sub-agents spawned: N, Actions taken: N, Skipped: N
+
+   ## Scorecard
+
+   | Dimension    | Score | Notes |
+   | ------------ | ----- | ----- |
+   | Completeness | ⭐⭐⭐⭐  | All 23 emails evaluated, housekeeping done |
+   | Accuracy     | ⭐⭐⭐⭐  | Actions aligned with rules, 1 edge case skipped |
+   | Judgment     | ⭐⭐⭐   | Skip rate 45% — reasonable given mixed inbox |
+   | Alert quality| ⭐⭐⭐⭐⭐ | 2 alerts, both actionable, <15 sec to triage |
+   ```
+
+   Score honestly. The scorecard is for detecting drift, not performing well.
+
+8. Update `agent_notes.md` if you learned something — including the **Failures &
+   Corrections** section if anything went wrong or a correction was applied
 
 ### Your Judgment
 
@@ -340,6 +413,24 @@ First run each day:
 
 You're not achieving inbox zero. You're removing debris. If you're touching more than
 30-40% of emails, you're too aggressive.
+
+### Agent Notes — Failures & Corrections
+
+`agent_notes.md` should include a **Failures & Corrections** section. When a run
+produces a mistake (misclassification, missed email, bad alert), log it here with the
+correction:
+
+```markdown
+## Failures & Corrections
+
+- **2025-01-15**: Archived a Venmo payment request (not a receipt) — correction: Venmo
+  "requests" stay in inbox, only "completed" payments get archived
+- **2025-01-14**: Skipped 3 newsletters that rules.md says to unsubscribe — correction:
+  check unsubscribe list before defaulting to skip on unknown newsletter senders
+```
+
+Each entry is a guardrail for the next run. Step 2 of "Each Run" reads these before
+processing.
 
 ### Security Checklist (Every Run)
 

--- a/workflows/forward-motion/AGENT.md
+++ b/workflows/forward-motion/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: forward-motion
-version: 0.1.0
+version: 0.2.0
 description:
   Fleet operations driver. Scans AI agent threads across Telegram, detects stuck bots,
   cleans up message noise, steers agents back on track, and surfaces what needs the
@@ -142,10 +142,14 @@ Ask:
 
 ### 5. Review Gate
 
+This workflow uses **Verification Level C** — a fresh cross-context verifier reviews all
+proposed messages before they are sent. This is mandatory and cannot be disabled
+(messages go to real people in real threads).
+
 Ask:
 
-- "Should I verify actions with a second model before executing?" (default: yes)
-- "Which model for review?" (default: a cheap/fast model)
+- "Which model should the verifier use?" (default: a cheap/fast model — context
+  separation matters more than model power)
 
 ### 6. Confirm & Save
 
@@ -212,8 +216,10 @@ Avoid splitting runtime into multiple tiny scripts unless there is a strong reas
 1. **Pre-flight:**
    - if `~/.tgcli/telethon-session.session` is missing, auto-run
      `skills/tgcli-topics/scripts/convert-session.py`
-   - read `rules.md`
-   - read `agent_notes.md` if present
+   - read `rules.md` (including trust level and cooldown state)
+   - read `agent_notes.md` — specifically the **Failures & Corrections** section. Build
+     a mental checklist of known pitfalls before processing anything. Past mistakes are
+     active guardrails, not passive history.
    - ensure DB schema exists and is current
 
 2. **Run the runtime entrypoint:**
@@ -223,10 +229,60 @@ Avoid splitting runtime into multiple tiny scripts unless there is a strong reas
    - auto-handles safe no-brainers
    - returns a review queue for judgment calls
 
-3. **Review before acting on judgment calls:**
-   - safe housekeeping can proceed automatically
-   - interventions, VIP-adjacent cleanup, shared/support-thread actions, and
-     cross-thread rollout decisions require review
+3. **Cross-context verification (proposed actions):**
+
+   Before executing any judgment call — interventions, VIP-adjacent cleanup,
+   shared/support-thread actions, cross-thread rollout decisions, or any message to be
+   sent — the proposed actions go through a fresh-context verifier.
+
+   **What the verifier receives:**
+   - The proposed action(s): message text, target thread/topic, action type
+   - The quality rubric (Message accuracy, Tone, Action correctness, Escalation
+     judgment)
+   - Relevant context: the thread messages that triggered the action
+   - The verifier prompt (below)
+
+   **What the verifier does NOT receive:**
+   - The worker's reasoning or intermediate analysis
+   - The full conversation history
+   - agent_notes.md or rules.md (the verifier judges output quality, not process)
+
+   **Verifier prompt:**
+
+   ```
+   Score each dimension on a 1-5 scale. For each:
+   - State the score (numeric)
+   - Cite specific actions/decisions that justify the score
+   - Flag issues with severity: critical (wrong action), warning (questionable
+     judgment), or minor (suboptimal but acceptable)
+
+   Dimensions:
+   - Message accuracy: Is the content factually correct about the thread/bot state?
+   - Tone: Does it match the message-type prefix expectations?
+   - Action correctness: Right thread, right action, right timing?
+   - Escalation judgment: Correctly decided what needs human attention vs auto-fix?
+
+   Scoring calibration:
+   - 5 means zero issues found. Reserve for genuinely flawless work.
+   - 3-4 is the honest range for most competent runs.
+   - Below 3 means you found concrete errors, not just uncertainties.
+
+   You are reviewing work done by another agent. You have no access to the
+   agent's reasoning — only its proposed output. If an action seems wrong,
+   flag it. If you can't determine whether an action was correct from the
+   output alone, flag that as a transparency issue.
+
+   Return: dimension scores, flagged issues with severity, overall confidence
+   (HIGH/MEDIUM/LOW).
+   ```
+
+   **Acting on verification results:**
+   - All clear (no critical flags, overall ⭐⭐⭐⭐ or above) → proceed to execute
+   - Warnings (overall ⭐⭐⭐) → proceed, log concerns in agent_notes.md
+   - Critical issues (overall ⭐⭐ or below) → abort the action, alert human
+
+   Safe housekeeping (duplicate cleanup, stale report removal) can still proceed without
+   verification — only judgment calls and outgoing messages require it.
 
 4. **Execute:**
    - steer bots in the same thread/topic
@@ -238,6 +294,13 @@ Avoid splitting runtime into multiple tiny scripts unless there is a strong reas
    - only completed work advances `last_processed_msg_id`
    - log meaningful actions to `actions_taken`
    - append to logs / update `agent_notes.md` when new patterns emerge
+
+6. **Score the run:**
+   - Score all four quality rubric dimensions (see Definition of Done)
+   - Record the scorecard in the daily log (see log format below)
+   - Check circuit breakers: update `consecutive_good_runs` and `cooldown_remaining` in
+     `rules.md`
+   - If new failures found, add to `agent_notes.md` under Failures & Corrections
 
 Preferred `agent_notes.md` pattern template:
 
@@ -256,6 +319,51 @@ patterns:
     confidence: high
     last_seen: "2026-04-11"
     review_required: false
+```
+
+**Failures & Corrections** section (read this BEFORE processing — these are active
+guardrails, not passive history):
+
+```markdown
+## Failures & Corrections
+
+### YYYY-MM-DD: Sent message to wrong topic
+
+- What happened: Steered bot in the general channel instead of its dedicated topic
+- Why it was wrong: Message was visible to all users, caused confusion
+- Correct action: Should have verified topic_id matched the thread where activity
+  happened
+- New rule: Always cross-check target topic_id against the fleet_map before sending
+- Applied to: Added to pre-send checklist in run loop
+```
+
+### Log Format
+
+Each run appends to the daily log in `logs/`. Include the scorecard:
+
+```markdown
+## Run: HH:MM
+
+### Actions
+
+- Threads scanned: N
+- New activity found: N threads
+- Actions taken: steered X, cleaned Y, escalated Z
+- Messages sent: N (max 1)
+- Errors: none
+- Verifier: passed | warnings | blocked (with details)
+
+### Scorecard
+
+| Dimension           | Stars          | Notes                                     |
+| ------------------- | -------------- | ----------------------------------------- |
+| Message accuracy    | ⭐⭐⭐⭐⭐ (5) | All facts verified against thread content |
+| Tone                | ⭐⭐⭐⭐ (4)   | Slightly formal for a Fleet Ops message   |
+| Action correctness  | ⭐⭐⭐⭐⭐ (5) | Correct threads, correct timing           |
+| Escalation judgment | ⭐⭐⭐⭐ (4)   | Borderline case escalated — reasonable    |
+| Overall             | ⭐⭐⭐⭐ (4)   |                                           |
+
+Confidence: HIGH Source: self | verified
 ```
 
 ### Judgment Guidelines
@@ -302,9 +410,79 @@ patterns:
 - **Don't delete human messages.** Only clean up bot/agent noise.
 - **VIP-adjacent cleanup requires review.** If deletion could affect a client,
   executive, or sensitive support thread, do not treat it as routine housekeeping.
-- **Review with second model before acting.** No unreviewed interventions.
+- **Cross-context verify before acting.** No unreviewed interventions. Judgment calls
+  and outgoing messages must pass the fresh-context verifier (see step 3 of Each Run).
 - **Message in the correct thread/topic.** Match where the activity happened.
 - **Identify yourself as DCOS** in all messages.
+
+## Definition of Done
+
+### Verification Level: C — Full Verification
+
+Forward-motion sends messages to real Telegram threads that other people see. Messages
+are irreversible and visible to others. Every proposed action is reviewed by a fresh
+cross-context verifier before execution.
+
+### Completion Criteria
+
+A run is complete when all of the following are true:
+
+- All fleet threads in `rules.md` have been scanned
+- `last_scanned_msg_id` is current for every scanned thread
+- Every thread with new activity has been assessed (action taken, escalated, or
+  explicitly skipped with reason)
+- No thread left in an ambiguous state without escalation
+- All actions logged to `actions_taken` with thread keys and descriptions
+- `last_processed_msg_id` advanced only for threads where work actually completed
+- At most 1 message sent to the human (batched)
+
+### Output Validation
+
+Structural checks before declaring a run done:
+
+- Log entry exists for this run with item counts and action summary
+- Every action in `actions_taken` has a non-null `action_type` and `description`
+- Every message sent used the correct message-type prefix label
+- Every message was sent to the correct thread/topic (matches where the activity
+  happened)
+- Scorecard is present in the log with all four dimensions scored
+
+### Quality Rubric
+
+| Dimension               | What it measures                                                        |
+| ----------------------- | ----------------------------------------------------------------------- |
+| **Message accuracy**    | Content is factually correct about the thread/bot state                 |
+| **Tone**                | Matches the message-type prefix expectations (urgency, formality, role) |
+| **Action correctness**  | Right thread, right action, right timing                                |
+| **Escalation judgment** | Correctly decided what needs human attention vs auto-fix                |
+
+Scoring scale:
+
+| Score      | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| ⭐⭐⭐⭐⭐ | Excellent — no issues, confident in all decisions             |
+| ⭐⭐⭐⭐   | Good — minor uncertainties, all resolved reasonably           |
+| ⭐⭐⭐     | Acceptable — some judgment calls the user might disagree with |
+| ⭐⭐       | Poor — likely errors, should flag for human review            |
+| ⭐         | Failed — wrong actions taken, rollback recommended            |
+
+### Circuit Breakers
+
+```
+If 3 consecutive runs score below ⭐⭐⭐ overall:
+  → Demote one trust level
+  → Reset consecutive_good_runs to 0
+  → Alert human: "Forward-motion quality degraded. Demoted to Level N."
+  → Log the pattern in agent_notes.md
+
+If a single run scores ⭐ on any dimension:
+  → Immediate alert to human
+  → Set cooldown_remaining to 10 in rules.md
+  → Reset consecutive_good_runs to 0
+  → Do NOT send the proposed message — abort the run
+  (Cooldown decrements by 1 each run. No trust advancement while
+  cooldown_remaining > 0, even if scores recover.)
+```
 
 ## Housekeeping
 

--- a/workflows/forward-motion/AGENT.md
+++ b/workflows/forward-motion/AGENT.md
@@ -245,7 +245,12 @@ Avoid splitting runtime into multiple tiny scripts unless there is a strong reas
    **What the verifier does NOT receive:**
    - The worker's reasoning or intermediate analysis
    - The full conversation history
-   - agent_notes.md or rules.md (the verifier judges output quality, not process)
+   - agent_notes.md (learned patterns — not needed to judge output)
+
+   **What the verifier also receives (routing context):**
+   - The fleet topic map from rules.md (thread names, topic IDs, intended purpose of
+     each thread) — required to validate "Action correctness: right thread, right topic"
+   - Without this, the verifier cannot assess whether the action was routed correctly
 
    **Verifier prompt:**
 

--- a/workflows/learning-loop/AGENT.md
+++ b/workflows/learning-loop/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: learning-loop
-version: 0.1.0
+version: 0.1.1
 description:
   Self-improvement system that captures corrections, detects patterns, and promotes
   validated learnings
@@ -43,6 +43,37 @@ logged to          grouped into     evidence get      archived,
 corrections.md     pattern          promoted to       preventing
                    candidates       permanent home    bloat
 ```
+
+## Definition of Done
+
+### Verification Level: A (log only)
+
+Internal pattern management — all state changes are append-only markdown writes to files
+the human can review. Promotions to workflow-specific agent_notes are low-risk and
+easily reversed. Fundamental operating changes are gated on human approval. This
+workflow already has its own verification pipeline (evidence chains, occurrence
+thresholds, constitutional validation) that exceeds Level A requirements.
+
+### Completion Criteria
+
+- **Capture:** Corrections written as positive-framed rules with pipeline metadata
+- **Detection:** Corrections grouped by similarity, pattern threshold applied,
+  candidates written to `patterns.md` with occurrence counts and confidence levels
+- **Validation:** Candidates with sufficient evidence checked against the validation
+  checklist (evidence quality, consistency, specificity, reversibility, scope) and
+  promoted to the correct destination or flagged for human review
+- **Decay:** Entries past their retention window archived to quarterly rollups,
+  corrections.md and patterns.md pruned of stale entries
+
+### Output Validation
+
+- Each phase logs its results (corrections reviewed, patterns detected/updated,
+  promotions made, entries archived)
+- Promoted patterns include the full evidence chain in HTML comment metadata (status,
+  promoted_to, promoted_on, occurrences, sources, confidence, date)
+- No pattern was promoted without meeting the occurrence threshold from `rules.md`
+- No fundamental operating change was promoted without `status: pending-human-review`
+- Archive summaries include counts by type and domain
 
 ---
 

--- a/workflows/llm-usage-report/AGENT.md
+++ b/workflows/llm-usage-report/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: llm-usage-report
-version: 0.1.0
+version: 0.1.1
 description:
   Daily LLM spend digest — previous day's cost broken down by session and model,
   delivered at noon
@@ -23,6 +23,40 @@ seconds over lunch.
 3. **Empathy pass** — Review your own draft: Is this useful? Is it alarming when it
    shouldn't be? Would someone want to read this at lunch?
 4. **Deliver** — Post the polished digest to Telegram
+
+## Definition of Done
+
+### Verification Level: A (log only)
+
+Pure reporting workflow — reads session data and delivers a digest. No mutations, no
+budget enforcement, no automated remediation. If the report is wrong, the human sees it
+and corrects.
+
+### Completion Criteria
+
+- Session and cron run data was gathered for the previous calendar day
+  (midnight-to-midnight CT)
+- Cost totals were computed with zero-cost sessions excluded
+- Top spenders were identified with model and description
+- Cost-by-model breakdown was calculated
+- Trend comparison (vs. day before) was computed
+- Anomaly checks were applied ($0.50 single session, $2.00 daily total, unusual models)
+- Empathy pass was performed — report tone matches the data (not alarming for normal
+  spend)
+- Digest was delivered to the Automation topic via Telegram
+- Log file was written to `logs/YYYY-MM-DD.md`
+
+### Output Validation
+
+- Report is under 15 lines
+- Total spend figure is present and non-negative
+- Session count is present
+- At least one top spender is listed (unless zero-spend day, which gets the quiet-day
+  message)
+- Trend direction (up/down/flat) is stated with percentage
+- Report reads as friendly and lunch-scannable, not robotic
+
+---
 
 ## Gathering Data
 

--- a/workflows/security-sentinel/AGENT.md
+++ b/workflows/security-sentinel/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: security-sentinel
-version: 0.1.0
+version: 0.1.1
 description: Threat intelligence and exposure mapping for the OpenClaw fleet
 ---
 
@@ -20,6 +20,48 @@ check fleet machines for exposure, and produce actionable intelligence. You're p
 - **SSH access** to fleet machines (via Tailscale)
 - **Fleet file** at `~/openclaw-fleet/` with machine inventory
 - **Alert channel** configured via `~/.openclaw/health-check-admin`
+
+## Definition of Done
+
+### Verification Level: B (self-score + circuit breakers)
+
+Proactive security research with fleet verification — misclassified severity can cause
+either false urgency (unnecessary CRITICAL alerts) or missed exposure (real threats
+rated LOW). Self-scoring tracks quality over time.
+
+### Completion Criteria
+
+- Web research was conducted across at least 3 distinct source categories (see Research
+  Sources)
+- Each finding was mapped against OpenClaw's architecture using the Exposure Mapping
+  matrix
+- Fleet machines were checked for any finding rated MEDIUM or above (if fleet exists)
+- Severity ratings were justified with specific evidence, not assumed
+- Findings were logged to `agent_notes.md` with assessment and resolution status
+- Weekly digest was written to `logs/YYYY-MM-DD-digest.md`
+- Actionable findings were routed per the Escalation severity table
+
+### Output Validation
+
+- Every finding includes: threat description, applicability assessment, severity rating
+  with justification
+- CRITICAL and HIGH findings include specific fleet verification results (not just
+  theoretical exposure)
+- Recommendations are actionable — "update package X to version Y" not "consider
+  updating"
+- No findings are copy-pasted from web sources without analysis of our specific exposure
+- Weekly digest covers all severity levels, not just the scary ones
+
+### Quality Rubric
+
+| Dimension                    | ⭐                              | ⭐⭐                          | ⭐⭐⭐                          | ⭐⭐⭐⭐                                                     | ⭐⭐⭐⭐⭐                                        |
+| ---------------------------- | ------------------------------- | ----------------------------- | ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------- |
+| Threat detection accuracy    | Missed a known active threat    | Found obvious threats only    | Covered major threat categories | Found emerging threats beyond obvious                        | Original analysis connecting disparate signals    |
+| Assessment quality           | Severity wildly wrong           | Over/under-rated by one level | Severity matches evidence       | Nuanced severity with clear justification                    | Severity + blast radius + exploitation difficulty |
+| Recommendation actionability | Vague "be careful" advice       | Generic mitigations           | Specific steps for our stack    | Steps + priority + owner (human vs. machine-security-review) | Steps + priority + verification commands          |
+| False positive rate          | >50% findings don't apply to us | 25-50% noise                  | <25% noise                      | <10% noise, most findings relevant                           | Every finding maps to real exposure               |
+
+---
 
 ## How You Think
 
@@ -172,6 +214,20 @@ At the end of each research cycle, produce a digest in `logs/YYYY-MM-DD-digest.m
 - [URLs and dates]
 ```
 
+## Circuit Breakers
+
+If 3 consecutive research cycles score below ⭐⭐⭐ on any rubric dimension, alert the
+admin via `~/.openclaw/health-check-admin` with:
+
+- Which dimension is failing (detection, assessment, recommendations, or false
+  positives)
+- The last 3 scores and what went wrong
+- Whether the issue is systematic (bad sources, stale heuristics) or one-off
+
+While in a circuit-breaker state, continue research but flag all findings as
+**unverified** and defer severity ratings to the admin. Do not auto-escalate CRITICAL or
+HIGH findings until the admin resets the circuit breaker.
+
 ## State Management
 
 ### agent_notes.md
@@ -187,6 +243,22 @@ Your accumulated knowledge. Grows over time. Includes:
 Update after every research cycle. This is how you get smarter over time — you don't
 re-research threats you've already assessed unless new information emerges.
 
+**Failures & Corrections section:** Track cases where severity was misrated, threats
+were missed, or recommendations were wrong. Format:
+
+```markdown
+## Failures & Corrections
+
+- [date]: Rated [threat] as LOW but it was exploited in the wild — should have been
+  HIGH. Missed signal: [what you should have checked].
+- [date]: Flagged [package] as compromised — false positive, was a test release. Better
+  check: [verify via official advisory DB, not just social media].
+```
+
+**Active guardrail:** Before starting any research cycle, read `agent_notes.md` and
+check the Failures & Corrections section. Apply corrected heuristics to current
+assessments — don't repeat the same severity miscalibration or source-trust mistake.
+
 ### rules.md
 
 User preferences for how you operate. Created during first-run setup interview.
@@ -195,6 +267,21 @@ User preferences for how you operate. Created during first-run setup interview.
 
 Execution history. One file per research cycle plus the weekly digest. Delete logs older
 than 90 days.
+
+Each weekly digest must end with a scorecard:
+
+```markdown
+## Scorecard
+
+| Dimension                    | Score      | Notes                                            |
+| ---------------------------- | ---------- | ------------------------------------------------ |
+| Threat detection accuracy    | ⭐⭐⭐⭐   | Covered 5 categories, found 1 emerging MCP issue |
+| Assessment quality           | ⭐⭐⭐     | 2 findings lacked fleet verification             |
+| Recommendation actionability | ⭐⭐⭐⭐   | All recs had specific steps                      |
+| False positive rate          | ⭐⭐⭐⭐⭐ | 0 false positives this cycle                     |
+```
+
+Be honest in self-scoring. The circuit breaker watches these scores.
 
 ## First Run — Setup Interview
 

--- a/workflows/security-sentinel/AGENT.md
+++ b/workflows/security-sentinel/AGENT.md
@@ -225,8 +225,10 @@ admin via `~/.openclaw/health-check-admin` with:
 - Whether the issue is systematic (bad sources, stale heuristics) or one-off
 
 While in a circuit-breaker state, continue research but flag all findings as
-**unverified** and defer severity ratings to the admin. Do not auto-escalate CRITICAL or
-HIGH findings until the admin resets the circuit breaker.
+**unverified** and note that confidence is degraded. CRITICAL and HIGH findings still
+escalate immediately — but prefix them with "UNVERIFIED:" so the admin knows quality is
+degraded. Never suppress urgent security alerts, even when the workflow is struggling.
+Only LOW and MEDIUM findings are deferred pending admin reset.
 
 ## State Management
 

--- a/workflows/security-sentinel/agent_notes.md
+++ b/workflows/security-sentinel/agent_notes.md
@@ -3,3 +3,10 @@
 This file grows over time as the sentinel researches threats and maps exposure.
 
 <!-- Populated automatically during research cycles. -->
+
+## Failures & Corrections
+
+<!-- Track severity miscalibrations, missed threats, and bad recommendations so they
+don't repeat. Format:
+- [date]: [what went wrong]. Next time: [corrected heuristic].
+-->

--- a/workflows/task-steward/AGENT.md
+++ b/workflows/task-steward/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: task-steward
-version: 0.1.0
+version: 0.1.1
 description: AI-powered task management with quality verification
 ---
 
@@ -14,6 +14,53 @@ quality delivery.
 - **Asana MCP** configured (see `skills/asana/SKILL.md`)
 - **Asana project** set up with sections (see TOOLS.md for IDs)
 - **Tags** created for workflow states
+
+## Definition of Done
+
+### Verification Level: B (self-score + circuit breakers)
+
+Creates and modifies tasks in Asana, spawns work and QA sub-agents, delivers results to
+human. Incorrect task creation is low-cost to fix (edit/delete in Asana), but incorrect
+work execution wastes time and erodes trust. User-only audience.
+
+### Completion Criteria
+
+- Incoming message was classified correctly (Q&A vs Task)
+- Tasks were created in the correct Asana section with clear name and success criteria
+- Work execution produced deliverables that match the original request
+- QA agent reviewed work before delivery (for tasks routed through READY FOR REVIEW)
+- Delivery notification included summary, deliverables, and Asana link
+- Periodic review checked for stuck/blocked tasks (if running as scheduled)
+- Log entry written with scorecard
+
+### Output Validation
+
+- Task descriptions include the original request (quoted), success criteria, and context
+- Work comments show incremental progress (not just start and finish)
+- QA review checked completeness, accuracy, and quality before approving
+- Delivery message is scannable — human can decide in <30 seconds whether to act on it
+- Blocked tasks are tagged and moved to WAITING with a clear explanation
+
+### Quality Rubric
+
+| Dimension               | ⭐ Poor                                                  | ⭐⭐ Below avg                                                | ⭐⭐⭐ Acceptable                                        | ⭐⭐⭐⭐ Good                                                  | ⭐⭐⭐⭐⭐ Excellent                                                    |
+| ----------------------- | -------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Classification accuracy | Q&A treated as Task or vice versa, causing delays        | Borderline cases misrouted occasionally                       | Clear cases routed correctly, borderline cases escalated | Nuanced classification using conversation signals              | Proactive — anticipated multi-step needs before human asked             |
+| Execution quality       | Work delivered incomplete or incorrect                   | Minor gaps in deliverables, missing edge cases                | Work matches request, basic quality met                  | Thorough work with good commentary and alternatives considered | Exceptional output that exceeds the brief, well-documented reasoning    |
+| QA pass rate            | QA rejected >50% of work, delivery delayed significantly | QA caught multiple issues per task                            | QA mostly approves, catches 1-2 minor issues             | QA approves clean work, feedback is polish-level               | QA adds value beyond checking — suggests improvements human appreciates |
+| Delivery clarity        | Delivery message is confusing or missing context         | Summary exists but requires re-reading the task to understand | Clear summary with deliverables listed                   | Summary + key findings + Asana link, scannable in <30 sec      | Human can act immediately — no follow-up questions needed               |
+
+The existing QA agent (think model) is the proto-quality-gate for this workflow — the
+rubric above complements it by scoring the end-to-end flow, not just the QA step.
+
+### Circuit Breakers
+
+3 consecutive runs scoring below ⭐⭐⭐ on any dimension → alert human with the pattern
+("Task Steward has scored below acceptable on [dimension] for 3 runs: [dates and
+scores]"). If graduated trust is implemented, auto-demote to supervised mode (all task
+executions require human approval before delivery) until human reviews and re-approves.
+
+---
 
 ## Core Concepts
 
@@ -41,6 +88,16 @@ quality delivery.
 ---
 
 ## The Flow
+
+### 0. Pre-Flight
+
+Before processing any messages or tasks:
+
+1. Read `rules.md` for preferences and IDs
+2. Read `agent_notes.md` (if exists) — check the **Failures & Corrections** section
+   first. If recent failures are logged, apply those corrections as guardrails before
+   proceeding (e.g., if last run misclassified a research request as Q&A, ensure similar
+   requests are routed as Tasks this run)
 
 ### 1. Task Classification
 
@@ -296,6 +353,70 @@ Local preferences for this installation:
 - If blocked >24 hours: alert human
 - VIP tasks (from NOW/TODAY): alert on any blocker immediately
 ```
+
+---
+
+## Log Format
+
+Each run appends to `logs/<YYYY-MM-DD>.md`. Include:
+
+```markdown
+# Task Steward Run
+
+Date: <timestamp>
+
+## Summary
+
+- Messages processed: <N>
+- Classified as Q&A: <N>
+- Classified as Task: <N>
+- Tasks created: <N>
+- Tasks completed and delivered: <N>
+- QA reviews: <N> (passed: <N>, rejected: <N>)
+- Blocked tasks found: <N>
+- Periodic review actions: <N>
+
+## Scorecard
+
+| Dimension               | Score      | Notes                                   |
+| ----------------------- | ---------- | --------------------------------------- |
+| Classification accuracy | ⭐⭐⭐⭐   | 3 tasks, 2 Q&A — all clearly routed     |
+| Execution quality       | ⭐⭐⭐     | 1 task needed revision after QA         |
+| QA pass rate            | ⭐⭐⭐⭐   | 2/3 passed first time, 1 minor revision |
+| Delivery clarity        | ⭐⭐⭐⭐⭐ | Human acted on all 3 without follow-up  |
+
+## Actions
+
+[For each task/Q&A: classification, action taken, outcome]
+
+## Errors
+
+[Any Asana API failures, sub-agent errors, or blocked task details]
+```
+
+Score honestly. The scorecard is for detecting drift, not performing well.
+
+---
+
+## Agent Notes — Failures & Corrections
+
+`agent_notes.md` should include a **Failures & Corrections** section. When a run
+produces a mistake (misclassification, bad task creation, QA miss), log it here with the
+correction:
+
+```markdown
+## Failures & Corrections
+
+- **2025-01-15**: Classified "research competitor pricing" as Q&A and gave a shallow
+  answer — should have been a Task with depth. Correction: any request involving
+  "research" + a topic that needs multiple sources → classify as Task
+- **2025-01-14**: QA approved a task where the deliverable was missing the requested
+  format (human wanted a table, got prose). Correction: QA must check deliverable format
+  against success criteria, not just content accuracy
+```
+
+Each entry is a guardrail for the next run. Step 0 (Pre-Flight) reads these before
+processing.
 
 ---
 


### PR DESCRIPTION
## Summary

Systematic upgrade of all 10 pre-packaged workflows to the workflow-builder v0.3.0 verification standards, applying the A/B/C verification level framework based on reversibility and audience.

- **Level A** (log only): calendar-steward, llm-usage-report, learning-loop — lightweight DoD, no scoring infrastructure
- **Level B** (self-score + circuit breakers): email-steward, contact-steward, task-steward, cron-healthcheck, security-sentinel, bridge-health — DoD with quality rubric, scorecard in logs, circuit breakers, active guardrails from past failures
- **Level C** (full verification): forward-motion — everything from B plus cross-context verifier for proposed messages before sending (only workflow that sends messages other people see)

Each workflow's rubric uses dimensions specific to what it actually does. Existing patterns (two-tier model, QA agents, confidence tables) are acknowledged as proto-quality-gates, not replaced.

## Test plan

- [ ] Read through each AGENT.md and verify DoD criteria are specific to that workflow
- [ ] Verify Level A workflows have NO scorecard/circuit breaker infrastructure
- [ ] Verify Level B workflows have scorecard + circuit breakers but NO cross-context verification
- [ ] Verify Level C (forward-motion) has full cross-context verifier with prompt template
- [ ] Verify no existing sections were destructively modified
- [ ] Verify version bumps are correct (patch for most, minor for forward-motion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)