### PR TITLE
fix(devops): address cursor[bot] review comments on PR #82

### DIFF
--- a/devops/scripts/archive_sessions.py
+++ b/devops/scripts/archive_sessions.py
@@ -16,15 +16,19 @@ from collections.abc import Iterable
 
 KEEP_COUNT_DEFAULT = 500
 KEEP_DAYS_DEFAULT = 14
-PROTECT_PREFIXES = (
-    "agent:main:main",
-    "agent:main:telegram:",
-    "agent:main:slack:",
-    "agent:main:imessage:",
-    "agent:main:whatsapp:",
-    "agent:main:discord:",
-)
 ARCHIVE_VERSION = 2
+
+
+def build_protect_prefixes(agent_id: str) -> tuple[str, ...]:
+    """Build protection prefixes dynamically based on agent_id."""
+    return (
+        f"agent:{agent_id}:main",
+        f"agent:{agent_id}:telegram:",
+        f"agent:{agent_id}:slack:",
+        f"agent:{agent_id}:imessage:",
+        f"agent:{agent_id}:whatsapp:",
+        f"agent:{agent_id}:discord:",
+    )
 
 
 class ArchiveError(Exception):
@@ -78,9 +82,9 @@ def atomic_json_write(path: Path, obj: Any) -> None:
     tmp_path = Path(tmp_name)
     try:
         with os.fdopen(fd, "w") as f:
+            # Pretty-print all JSON files with consistent formatting
             indent = 2 if path.suffix == ".json" else None
-            separators = (",", ":") if path.name == "sessions.json" else None
-            json.dump(obj, f, indent=indent, separators=separators)
+            json.dump(obj, f, indent=indent)
             f.flush()
             os.fsync(f.fileno())
         tmp_path.chmod(0o600)
@@ -225,8 +229,9 @@ def run_archive(
     sessions_dir = state_dir / "agents" / agent_id / "sessions"
     store_path = sessions_dir / "sessions.json"
     latest_link = archive_root / agent_id / "latest"
+    protect_prefixes = build_protect_prefixes(agent_id)
     store = load_store(store_path)
-    kept, archived = collect_candidates(store, keep_count, keep_days, PROTECT_PREFIXES)
+    kept, archived = collect_candidates(store, keep_count, keep_days, protect_prefixes)
 
     by_kind: dict[str, int] = {}
     for key, _entry in archived:
@@ -268,16 +273,13 @@ def run_archive(
 
     atomic_json_write(temp_dir / "summary.json", summary)
 
-    new_store = {k: v for k, v in kept}
-    atomic_json_write(store_path, new_store)
-
+    # Finalize archive directory BEFORE pruning sessions.json to avoid data loss window
     ensure_parent(final_dir)
     if final_dir.exists():
         raise ArchiveError(f"Archive destination already exists: {final_dir}")
     temp_dir.rename(final_dir)
 
-    # Fix archivedTranscript paths: they were recorded relative to temp_dir,
-    # which no longer exists after the rename. Update to final_dir paths.
+    # Fix archivedTranscript paths in both manifest.jsonl AND individual entry files
     temp_prefix = str(temp_dir)
     final_prefix = str(final_dir)
     for m in manifests:
@@ -287,9 +289,23 @@ def run_archive(
             m["archivedTranscript"] = str(m["archivedTranscript"]).replace(
                 temp_prefix, final_prefix, 1
             )
+
+    # Write updated manifest.jsonl
     (final_dir / "manifest.jsonl").write_text(
         "".join(json.dumps(m) + "\n" for m in manifests)
     )
+
+    # Rewrite individual entry files with corrected paths
+    entries_dir = final_dir / "entries"
+    for m in manifests:
+        key = m["sessionKey"]
+        safe_name = key.replace("/", "_").replace(":", "__")
+        entry_path = entries_dir / f"{safe_name}.json"
+        entry_path.write_text(json.dumps(m, indent=2))
+
+    # Now that archive is safely finalized, prune sessions.json
+    new_store = {k: v for k, v in kept}
+    atomic_json_write(store_path, new_store)
 
     delete_failures = delete_sources(sources_to_delete)
     summary["runDir"] = str(final_dir)


### PR DESCRIPTION
## Summary

Addresses 4 code review comments from cursor[bot] on PR #82 (session archive tooling):

1. **HIGH**: Eliminated data loss window by finalizing archive directory BEFORE pruning sessions.json
2. **MEDIUM**: Made PROTECT_PREFIXES dynamic to incorporate actual agent_id (not hardcoded "agent:main:...")
3. **MEDIUM**: Fixed contradictory JSON formatting (removed compact separators conflicting with indent=2)
4. **LOW**: Rewrite per-entry JSON files after rename to fix stale temp-dir transcript paths

## Changes

- `devops/scripts/archive_sessions.py`:
  - Replaced hardcoded `PROTECT_PREFIXES` constant with `build_protect_prefixes(agent_id)` function
  - Moved `temp_dir.rename(final_dir)` before `atomic_json_write(store_path, new_store)` to avoid data loss
  - Removed contradictory `separators` parameter from `atomic_json_write`
  - Added rewrite loop for individual entry files to fix transcript paths post-rename

## Test plan

- [ ] Verify script runs without errors: `./devops/scripts/archive_sessions.py --dry-run`
- [ ] Confirm PROTECT_PREFIXES dynamically matches agent_id
- [ ] Check that archive completes before sessions.json is pruned
- [ ] Validate both manifest.jsonl and entries/*.json have correct paths after rename

Closes cursor[bot] comments: #82 (comment 3083766012, 3083766024, 3083766030, 3083766035)

🤖 Generated with [Claude Code](https://claude.com/claude-code)