### PR TITLE
fix: correct openclaw-config clone path in docs

### DIFF
--- a/devops/machine-security-review.md
+++ b/devops/machine-security-review.md
@@ -331,7 +331,7 @@ skill can do anything the user can do.
 Skills run from two locations that must both be checked:
 
 1. **Config repo** (find it via `CLAUDE.local.md` or by searching for a directory
-   containing `skills/` with a `VERSION` file — commonly `~/.openclaw-config/` or
+   containing `skills/` with a `VERSION` file — commonly `~/src/openclaw-config/` or
    wherever the user cloned the repo): Run `git diff HEAD -- skills/` — any local
    modifications are findings.
 2. **Deployed workspace copies** (the actual executables that run): The openclaw

--- a/skills/openclaw/SKILL.md
+++ b/skills/openclaw/SKILL.md
@@ -29,7 +29,7 @@ Manages your openclaw-config installation.
 
 Do these steps in order:
 
-1. **Clone repo** to `~/.openclaw-config`
+1. **Clone repo** to `~/src/openclaw-config`
 
 2. **Copy templates** to workspace root (don't overwrite existing): AGENTS.md, SOUL.md,
    USER.md, TOOLS.md, HEARTBEAT.md, IDENTITY.md
@@ -40,10 +40,10 @@ Do these steps in order:
 4. **Copy skills** to `skills/`
 
 5. **Optional: Add workflows** — Ask if they want any workflows. List available
-   workflows from `~/.openclaw-config/workflows/`.
+   workflows from `~/src/openclaw-config/workflows/`.
 
    If yes for a workflow:
-   - Copy all upstream-owned files from `~/.openclaw-config/workflows/<name>/` to
+   - Copy all upstream-owned files from `~/src/openclaw-config/workflows/<name>/` to
      `workflows/<name>/`, preserving directory structure (e.g., `platforms/` subdirs)
    - **Never copy user-owned files:** `rules.md`, `agent_notes.md`, `preferences.md`,
      `processed.md`, `logs/`
@@ -86,7 +86,7 @@ Do these steps in order:
    - Resolve the claude CLI path with `which claude` — use the full path in the cron job
    - Install the cron job (substitute CLAUDE_PATH with the resolved path):
      ```
-     0 0,7-23 * * * test -f "$HOME/.openclaw-config/devops/health-check.md" && flock -n "$HOME/.openclaw/health-check.lock" CLAUDE_PATH -p "Run health check" --model simple --append-system-prompt-file "$HOME/.openclaw-config/devops/health-check.md" --dangerously-skip-permissions --max-budget-usd 5.00 >> "$HOME/.openclaw/health-check.log" 2>&1
+     0 0,7-23 * * * test -f "$HOME/src/openclaw-config/devops/health-check.md" && flock -n "$HOME/.openclaw/health-check.lock" CLAUDE_PATH -p "Run health check" --model simple --append-system-prompt-file "$HOME/src/openclaw-config/devops/health-check.md" --dangerously-skip-permissions --max-budget-usd 5.00 >> "$HOME/.openclaw/health-check.log" 2>&1
      ```
    - Verify: `crontab -l | grep health-check`
    - Do a test run: execute the claude command once and verify it produces output
@@ -106,7 +106,7 @@ Do these steps in order:
 
 # Update
 
-Compare `.openclaw/installed-version` with `~/.openclaw-config/VERSION`.
+Compare `.openclaw/installed-version` with `~/src/openclaw-config/VERSION`.
 
 If newer: pull, update skills (safe to overwrite), update templates only if user hasn't
 modified them, update version file, report changes.

--- a/workflows/contact-steward/platforms/quo.md
+++ b/workflows/contact-steward/platforms/quo.md
@@ -3,7 +3,7 @@
 ## Tools
 
 Quo (formerly OpenPhone) access is through the `quo` CLI at
-`~/.openclaw-config/skills/quo/quo`. Requires `QUO_API_KEY` environment variable
+`~/src/openclaw-config/skills/quo/quo`. Requires `QUO_API_KEY` environment variable
 (injected by OpenClaw automatically).
 
 ### Listing Conversations


### PR DESCRIPTION
## Summary

- Corrects default clone path from `~/.openclaw-config` to `~/src/openclaw-config` across 3 docs
- Files: `machine-security-review.md`, `SKILL.md` (openclaw), `quo.md` platform guide

## Test plan
- [x] Grep confirms zero remaining `~/.openclaw-config` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)