### PR TITLE
chore: rewrite Tailscale dashboard security with serve approach

### DIFF
--- a/devops/machine-setup.md
+++ b/devops/machine-setup.md
@@ -220,6 +220,24 @@ column (not `-`)
 
 **Health:** `openclaw health` — should report gateway up, channels connected
 
+### Remote Dashboard Access
+
+The Control UI must be accessible over HTTPS (browsers block Web Crypto on plain HTTP,
+which breaks device auth). See `tailscale-dashboard-security.md` for the full setup.
+Quick version:
+
+1. Check if the Tailscale network extension is installed:
+   `systemextensionsctl list | grep -i tailscale`
+2. If extension present → use `tailscale serve --bg --https=443 http://127.0.0.1:18789`
+3. If extension missing → use `tailscale funnel --bg --https=443 http://127.0.0.1:18789`
+4. Verify: `curl -sS https://<hostname>.ts.net/ | head -1` — should return `HTTP/2 200`
+
+**Verify funnel/serve is active:** `tailscale funnel status --json` should show proxy
+config, not `{}`.
+
+**Tailscale must auto-start at login** for the funnel to persist across reboots. Check:
+System Settings > General > Login Items > Tailscale.
+
 ---
 
 ## Backup

--- a/devops/machine-setup.md
+++ b/devops/machine-setup.md
@@ -226,17 +226,23 @@ The Control UI must be accessible over HTTPS (browsers block Web Crypto on plain
 which breaks device auth). See `tailscale-dashboard-security.md` for the full setup.
 Quick version:
 
-1. Check if the Tailscale network extension is installed:
-   `systemextensionsctl list | grep -i tailscale`
-2. If extension present → use `tailscale serve --bg --https=443 http://127.0.0.1:18789`
-3. If extension missing → use `tailscale funnel --bg --https=443 http://127.0.0.1:18789`
-4. Verify: `curl -sS https://<hostname>.ts.net/ | head -1` — should return `HTTP/2 200`
+1. **DNS fix (Homebrew Tailscale):** Create `/etc/resolver/ts.net` so `*.ts.net`
+   resolves to tailnet IPs:
+   ```bash
+   echo "nameserver 100.100.100.100" | sudo tee /etc/resolver/ts.net
+   ```
+2. **Set up Tailscale Serve:** `tailscale serve --bg --https=443 http://127.0.0.1:18789`
+3. **Verify:** `curl -sS https://<hostname>.ts.net/ | head -1` — should return
+   `HTTP/2 200`
 
-**Verify funnel/serve is active:** `tailscale funnel status --json` should show proxy
-config, not `{}`.
+**Verify serve is active:** `tailscale serve status --json` should show proxy config,
+not `{}`. If it returns `{}`, the DNS fix is missing.
 
-**Tailscale must auto-start at login** for the funnel to persist across reboots. Check:
+**Tailscale must auto-start at login** for serve to persist across reboots. Check:
 System Settings > General > Login Items > Tailscale.
+
+**Do NOT use `tailscale funnel`** unless serve is impossible — funnel exposes the
+dashboard to the public internet.
 
 ---
 

--- a/devops/machine-setup.md
+++ b/devops/machine-setup.md
@@ -227,7 +227,8 @@ which breaks device auth). See `tailscale-dashboard-security.md` for the full se
 Quick version:
 
 1. **DNS fix (Homebrew Tailscale):** Create `/etc/resolver/ts.net` so `*.ts.net`
-   resolves to tailnet IPs:
+   resolves to tailnet IPs. See `tailscale-dns-troubleshooting.md` for why. Apply on
+   every machine (server + clients):
    ```bash
    echo "nameserver 100.100.100.100" | sudo tee /etc/resolver/ts.net
    ```

--- a/devops/machine-setup.md
+++ b/devops/machine-setup.md
@@ -230,11 +230,12 @@ Quick version:
    resolves to tailnet IPs. See `tailscale-dns-troubleshooting.md` for why. Apply on
    every machine (server + clients):
    ```bash
+   sudo mkdir -p /etc/resolver
    echo "nameserver 100.100.100.100" | sudo tee /etc/resolver/ts.net
    ```
 2. **Set up Tailscale Serve:** `tailscale serve --bg --https=443 http://127.0.0.1:18789`
-3. **Verify:** `curl -sS https://<hostname>.ts.net/ | head -1` — should return
-   `HTTP/2 200`
+3. **Verify:** `curl -sS -o /dev/null -w "%{http_code}" https://<hostname>.ts.net/` —
+   should return `200`
 
 **Verify serve is active:** `tailscale serve status --json` should show proxy config,
 not `{}`. If it returns `{}`, the DNS fix is missing.

--- a/devops/tailscale-dashboard-security.md
+++ b/devops/tailscale-dashboard-security.md
@@ -2,173 +2,143 @@
 
 ## Overview
 
-Two approaches to expose the OpenClaw Control UI over HTTPS on Tailscale. Choose the one
-that matches your machine's state.
+Expose the OpenClaw Control UI over HTTPS on Tailscale with tailnet-only access. No
+public internet exposure.
 
-| Approach        | When to use                                          | Access scope |
-| --------------- | ---------------------------------------------------- | ------------ |
-| **Serve + TLS** | Tailscale network extension is installed and working | Tailnet only |
-| **Funnel**      | Network extension missing or DNS resolution broken   | Public\*     |
+This solves the core problem: browsers block `window.crypto.subtle` (Web Crypto API) on
+non-secure contexts. Without HTTPS, the Control UI can't complete device identity checks
+and gets stuck at the login page.
 
-\* Funnel is public, but gateway password auth still protects access.
-
-Both approaches solve the same underlying problem: browsers block `window.crypto.subtle`
-(Web Crypto API) on non-secure contexts. Without HTTPS, the Control UI can't complete
-device identity checks and gets stuck at the login page.
+**Architecture:** Gateway binds to loopback → Tailscale Serve proxies HTTPS on port 443
+to `127.0.0.1:18789` → Tailscale's DNS resolves MagicDNS hostnames to 100.x IPs.
 
 ---
 
-## Approach 1: Serve + TLS (Preferred)
+## Step 1: DNS Setup (Required for Homebrew-installed Tailscale)
 
-Requires the Tailscale **network extension** to be installed and active. This intercepts
-MagicDNS queries so `*.ts.net` hostnames resolve to the local Tailscale IP (100.x)
-instead of public ingress IPs.
+The Homebrew `tailscale` formula uses the `utun` interface (no system/network
+extension). This means Tailscale can't intercept DNS queries at the OS level. Without
+intervention, `*.ts.net` hostnames resolve to Tailscale's public ingress IPs (209.x)
+instead of tailnet IPs (100.x), and `tailscale serve` silently fails.
 
-### Prerequisites
-
-1. Network extension installed and loaded:
+**Fix:** Create a macOS resolver file that routes `*.ts.net` queries to Tailscale's DNS:
 
 ```bash
-systemextensionsctl list | grep -i tailscale
-# Should show at least 1 Tailscale extension
+echo "nameserver 100.100.100.100" | sudo tee /etc/resolver/ts.net
+sudo dscacheutil -flushcache
+sudo killall -HUP mDNSResponder 2>/dev/null || true
 ```
 
-2. MagicDNS resolves to 100.x:
+**Verify:**
 
 ```bash
-dig +short <your-machine>.<tailnet>.ts.net
-# Should return 100.x.x.x, not 209.x.x.x
+# System resolver (NOT dig or nslookup — they bypass the system resolver)
+python3 -c "import socket; print(socket.getaddrinfo('your-host.tailae0f4b.ts.net', 443)[0][4][0])"
+# Should print: 100.x.x.x
+
+# Or use curl
+curl -sS --max-time 5 https://your-host.tailae0f4b.ts.net/ -o /dev/null -w "%{remote_ip}\n"
+# Should print: 100.x.x.x
 ```
 
-If either check fails, use **Approach 2 (Funnel)** instead.
+> **Note:** `dig` and `nslookup` bypass the macOS system resolver and won't show the
+> correct IP. Use `python3`, `curl`, or Node.js to test — these use the system resolver.
 
-### Steps
+**Persistence:** This file survives reboots. Deploy it as part of machine setup.
+
+---
+
+## Step 2: Set Up Tailscale Serve
 
 ```bash
-# Generate Tailscale TLS certs
-MAGICDNS="<your-machine>.<tailnet>.ts.net"
-mkdir -p ~/.openclaw/tls
-cd ~/.openclaw/tls
-tailscale cert "$MAGICDNS"
-mv "$MAGICDNS.crt" server.crt
-mv "$MAGICDNS.key" server.key
+# Clean any existing config
+tailscale funnel reset 2>/dev/null || true
+tailscale serve reset 2>/dev/null || true
 
-# Set up tailscale serve (proxy to loopback gateway)
+# Set up serve (tailnet-only)
 tailscale serve --bg --https=443 http://127.0.0.1:18789
 ```
 
-### Gateway Config
-
-```json5
-"gateway": {
-  "bind": "loopback",
-  "auth": {
-    "mode": "password",
-    "password": "<choose-password>"
-  },
-  "tls": {
-    "enabled": true,
-    "certPath": "/Users/<user>/.openclaw/tls/server.crt",
-    "keyPath": "/Users/<user>/.openclaw/tls/server.key"
-  },
-  "tailscale": {
-    "mode": "off",
-    "resetOnExit": false
-  },
-  "controlUi": {
-    "enabled": true,
-    "allowedOrigins": [
-      "https://<your-machine>.<tailnet>.ts.net"
-    ]
-  }
-}
-```
-
-### Verify
+**Verify:**
 
 ```bash
-tailscale serve status --json   # should show proxy config
-curl -sS https://<your-machine>.<tailnet>.ts.net/ | head -5  # HTTP 200
+tailscale serve status --json
+# Should show HTTPS on 443, proxy to http://127.0.0.1:18789
+# Should NOT have AllowFunnel key
 ```
+
+**Persistence:** `tailscale serve --bg` persists in Tailscale's state. Survives gateway
+restarts and reboots (Tailscale starts at login).
 
 ---
 
-## Approach 2: Funnel (When Network Extension Is Missing)
+## Step 3: Gateway Config
 
-Uses Tailscale's public proxy servers instead of local DNS interception. No network
-extension required.
+```json5
+{
+  gateway: {
+    port: 18789,
+    mode: "local",
+    bind: "loopback",
+    auth: {
+      mode: "token",
+      token: "<generate-with: openssl rand -hex 32>",
+      password: "<fallback-password>",
+    },
+    tailscale: {
+      mode: "off",
+      resetOnExit: true,
+    },
+    controlUi: {
+      enabled: true,
+      dangerouslyDisableDeviceAuth: false,
+      allowedOrigins: ["https://<your-machine>.<tailnet>.ts.net"],
+    },
+  },
+}
+```
 
-**Why network extensions go missing:** On macOS, the Tailscale app may be installed
-without the system extension (e.g. Mac App Store version, or the extension was removed
-in Privacy & Security settings). Without it, MagicDNS queries for `*.ts.net` fall
-through to the local resolver and return Tailscale's public ingress IPs (209.x) instead
-of the tailnet IP (100.x). `tailscale serve` can't intercept traffic that never reaches
-the local machine.
+Key points:
 
-**Check:** `systemextensionsctl list` — if it shows 0 Tailscale extensions, use this
-approach.
+- **`bind: loopback`** — gateway only on 127.0.0.1. Tailscale is the only way in.
+- **`auth.mode: token`** — strong shared secret required for each connection. Set both
+  `token` and `password` for two-factor auth (token + password).
+- **`dangerouslyDisableDeviceAuth: false`** — device identity checks are active. HTTPS
+  from Tailscale Serve provides the secure context needed for Web Crypto.
+- **`allowedOrigins`** — restricted to the MagicDNS hostname over HTTPS.
 
-### Steps
+### Access
+
+Open in browser:
+
+```
+https://<your-machine>.<tailnet>.ts.net/
+```
+
+The Control UI connects via WebSocket. Enter:
+
+1. **Gateway Token** — the `openssl rand -hex 32` value from config
+2. **Password** — the fallback password from config
+
+---
+
+## Alternative: Funnel (Public Internet — Use Only If Serve Doesn't Work)
+
+If the DNS fix in Step 1 doesn't work (e.g. on a Linux machine without `/etc/resolver`),
+use `tailscale funnel` as a fallback. This exposes the dashboard to the **public
+internet** via Tailscale's proxy servers, but gateway auth still protects it.
 
 ```bash
-# Set up funnel (proxies through Tailscale's public servers)
 tailscale funnel --bg --https=443 http://127.0.0.1:18789
 ```
 
-### Gateway Config
+Security implications:
 
-```json5
-"gateway": {
-  "bind": "loopback",
-  "auth": {
-    "mode": "password",
-    "password": "<choose-password>"
-  },
-  "tailscale": {
-    "mode": "off",
-    "resetOnExit": false
-  },
-  "controlUi": {
-    "enabled": true,
-    "dangerouslyDisableDeviceAuth": true,
-    "allowedOrigins": [
-      "https://<your-machine>.<tailnet>.ts.net"
-    ]
-  }
-}
-```
-
-### Verify
-
-```bash
-tailscale funnel status --json   # should show AllowFunnel config
-curl -sS https://<your-machine>.<tailnet>.ts.net/ | head -5  # HTTP 200
-```
-
----
-
-## Persistence Across Restarts
-
-`tailscale funnel --bg` persists in Tailscale's state and survives gateway restarts. It
-also survives reboots because Tailscale itself starts at login.
-
-No additional launchd agents are needed — Tailscale manages the funnel config
-internally.
-
-### Tailscale App Auto-Start
-
-Make sure Tailscale launches at login:
-
-```bash
-# Verify Tailscale is set to open at login
-osascript -e 'tell application "System Events" to get the name of every login item' | grep -i tailscale
-```
-
-If missing, add it via System Settings > General > Login Items, or:
-
-```bash
-osascript -e 'tell application "System Events" to make login item at end with properties {path:"/Applications/Tailscale.app", hidden:false}'
-```
+- Anyone on the internet who discovers the URL can attempt authentication
+- Password-only auth (device auth is auto-approved for loopback connections)
+- Tailscale's proxy servers see unencrypted HTTP traffic between their edge and your
+  machine
+- Use a **strong** password if funnel is required
 
 ---
 
@@ -177,55 +147,53 @@ osascript -e 'tell application "System Events" to make login item at end with pr
 ### Serve config disappears immediately
 
 **Symptom:** `tailscale serve --bg` reports success, but `tailscale serve status --json`
-returns `{}` right after.
+returns `{}`.
 
-**Cause:** Tailscale network extension is not installed. The serve config needs the
-network extension to route traffic through WireGuard. Without it, the daemon discards
-the config.
+**Cause:** DNS not intercepting `*.ts.net` queries. Without the resolver file, the
+system resolves the hostname to public IPs, and Tailscale's daemon discards the serve
+config.
 
-**Fix:** Use `tailscale funnel` instead (Approach 2), or install the network extension.
+**Fix:** Apply Step 1 (DNS setup).
 
 ### Etag mismatch errors
 
-**Symptom:** `tailscale funnel` or `tailscale serve` returns "Another client is changing
-the serve config" or "preconditions failed: etag mismatch."
+**Symptom:** "Another client is changing the serve config" or "preconditions failed:
+etag mismatch."
 
-**Cause:** Race condition between multiple Tailscale processes (CLI, app UI).
+**Cause:** Race condition between multiple Tailscale processes.
 
 **Fix:**
 
 ```bash
-tailscale funnel reset
-tailscale serve reset
+tailscale funnel reset 2>/dev/null; tailscale serve reset 2>/dev/null
 sleep 2
-tailscale funnel --bg --https=443 http://127.0.0.1:18789
+tailscale serve --bg --https=443 http://127.0.0.1:18789
 ```
 
 ### DNS resolves to 209.x instead of 100.x
 
-**Symptom:** `dig +short <hostname>.ts.net` returns 209.177.x.x addresses.
+**Symptom:** curl or browser gets `SSL_ERROR_SYSCALL` or connection refused.
 
-**Cause:** Tailscale network extension not intercepting DNS for `*.ts.net`.
+**Cause:** `/etc/resolver/ts.net` missing or Tailscale not running.
 
 **Diagnose:**
 
 ```bash
-# Check DNS config
-scutil --dns | grep -A3 tailscale
-# If "reach: 0x00000000 (Not Reachable)" — extension not loaded
+# Check resolver file exists
+cat /etc/resolver/ts.net  # should show: nameserver 100.100.100.100
 
-# Check Tailscale's DNS directly
+# Check Tailscale DNS directly
 nslookup <hostname>.ts.net 100.100.100.100
-# If this returns 100.x — Tailscale DNS works, but macOS isn't using it
-```
 
-**Fix:** Use funnel (Approach 2), or install the network extension.
+# Check system resolver
+python3 -c "import socket; print(socket.getaddrinfo('<hostname>.ts.net', 443)[0][4][0])"
+```
 
 ### Gateway bind:loopback still listens on all interfaces
 
-**Symptom:** `lsof -Pn -i :18789` shows `*:18789` instead of `127.0.0.1:18789`.
+**Symptom:** `lsof -Pn -i :18789` shows `*:18789`.
 
-**Cause:** Gateway may need a full restart (not just SIGUSR1 reload) to rebind.
+**Cause:** Gateway needs full restart to rebind.
 
 **Fix:**
 
@@ -233,19 +201,23 @@ nslookup <hostname>.ts.net 100.100.100.100
 openclaw gateway restart
 sleep 3
 lsof -Pn -i :18789 | grep LISTEN
-# Should show 127.0.0.1:18789
+# Should show: 127.0.0.1:18789
 ```
 
 ---
 
-## Security Notes
+## Security Summary
 
-- **Loopback bind is mandatory.** Always bind the gateway to `loopback` so Tailscale is
-  the only way in. Never bind to `lan` or `tailnet` when using funnel.
-- **Password auth protects funnel access.** Even though funnel is public, the gateway
-  password (`million1` or stronger) is required.
-- **`dangerouslyDisableDeviceAuth`** is needed with funnel because the device identity
-  check relies on Web Crypto APIs that require a secure context with loopback bind. Keep
-  this true when using funnel; turn it off when using Approach 1 (Serve + TLS).
-- **Upgrade path:** When the Tailscale network extension is available, switch to
-  Approach 1 (Serve + TLS) and remove `dangerouslyDisableDeviceAuth`.
+| Layer     | What protects you                                 |
+| --------- | ------------------------------------------------- |
+| Network   | Tailnet only — not reachable from public internet |
+| Transport | HTTPS via Tailscale Serve (Let's Encrypt certs)   |
+| Auth      | Gateway token (shared secret) + password          |
+| Device    | Browser-bound device identity via Web Crypto      |
+| Origin    | Only `https://<hostname>.ts.net` accepted         |
+
+**Do not set `dangerouslyDisableDeviceAuth: true`** unless in a break-glass emergency.
+The HTTPS context from Tailscale Serve makes device auth work without issues.
+
+**Do not use `bind: lan` or `bind: tailnet`** with serve — always use `bind: loopback`
+so Tailscale is the only ingress path.

--- a/devops/tailscale-dashboard-security.md
+++ b/devops/tailscale-dashboard-security.md
@@ -24,6 +24,7 @@ instead of tailnet IPs (100.x), and `tailscale serve` silently fails.
 **Fix:** Create a macOS resolver file that routes `*.ts.net` queries to Tailscale's DNS:
 
 ```bash
+sudo mkdir -p /etc/resolver
 echo "nameserver 100.100.100.100" | sudo tee /etc/resolver/ts.net
 sudo dscacheutil -flushcache
 sudo killall -HUP mDNSResponder 2>/dev/null || true

--- a/devops/tailscale-dashboard-security.md
+++ b/devops/tailscale-dashboard-security.md
@@ -33,11 +33,11 @@ sudo killall -HUP mDNSResponder 2>/dev/null || true
 
 ```bash
 # System resolver (NOT dig or nslookup — they bypass the system resolver)
-python3 -c "import socket; print(socket.getaddrinfo('your-host.tailae0f4b.ts.net', 443)[0][4][0])"
+python3 -c "import socket; print(socket.getaddrinfo('your-host.your-tailnet.ts.net', 443)[0][4][0])"
 # Should print: 100.x.x.x
 
 # Or use curl
-curl -sS --max-time 5 https://your-host.tailae0f4b.ts.net/ -o /dev/null -w "%{remote_ip}\n"
+curl -sS --max-time 5 https://your-host.your-tailnet.ts.net/ -o /dev/null -w "%{remote_ip}\n"
 # Should print: 100.x.x.x
 ```
 

--- a/devops/tailscale-dashboard-security.md
+++ b/devops/tailscale-dashboard-security.md
@@ -1,79 +1,75 @@
-# Securing OpenClaw Dashboard on Tailscale (Best Practices)
+# Securing OpenClaw Dashboard on Tailscale
 
-## Objective
+## Overview
 
-Safely expose the OpenClaw Gateway Dashboard to your Tailscale network (tailnet) with
-end-to-end encryption, browser compatibility for Web Crypto APIs (WebSockets device
-identity), and strict access controls.
+Two approaches to expose the OpenClaw Control UI over HTTPS on Tailscale. Choose the one
+that matches your machine's state.
 
-## Research & The Problem
+| Approach        | When to use                                          | Access scope |
+| --------------- | ---------------------------------------------------- | ------------ |
+| **Serve + TLS** | Tailscale network extension is installed and working | Tailnet only |
+| **Funnel**      | Network extension missing or DNS resolution broken   | Public\*     |
 
-When accessing the OpenClaw Dashboard via HTTP over an IP address (e.g.,
-`http://<tailscale-ip>:18789`), modern browsers block operations under
-`window.crypto.subtle` (the Web Crypto API) if the originating connection is not
-considered a "Secure Context". This prevents the necessary device identity checks from
-completing, trapping the user at the login page.
+\* Funnel is public, but gateway password auth still protects access.
 
-While it is possible to bypass the check using `dangerouslyDisableDeviceAuth = true`,
-doing so compromises defense-in-depth measures.
+Both approaches solve the same underlying problem: browsers block `window.crypto.subtle`
+(Web Crypto API) on non-secure contexts. Without HTTPS, the Control UI can't complete
+device identity checks and gets stuck at the login page.
 
-Another option is to proxy the connection through `tailscale serve`. While this
-correctly provisions Let's Encrypt certificates and establishes HTTPS, we encountered
-proxy loops and connection resets on macOS.
+---
 
-## The Solution
+## Approach 1: Serve + TLS (Preferred)
 
-The most secure, industry-standard approach for Tailscale applications without proxy
-sidecars is to:
+Requires the Tailscale **network extension** to be installed and active. This intercepts
+MagicDNS queries so `*.ts.net` hostnames resolve to the local Tailscale IP (100.x)
+instead of public ingress IPs.
 
-1. **Bind locally to the Tailnet interface** so the gateway daemon drops any traffic
-   from the local physical LAN (`192.168...`) or the public web.
-2. **Terminate TLS natively in the OpenClaw Gateway** by providing the gateway the
-   cryptographic material (`.crt`, `.key`) provided by Tailscale's MagicDNS.
-3. **Use a gateway password** as an explicit multi-factor check instead of just an
-   opaque token.
+### Prerequisites
 
-### Implementation Steps
-
-#### Generate local Tailscale Certificates
-
-Retrieve the trusted TLS certificates specifically for your Tailscale node's MagicDNS
-hostname (e.g., `<your-machine>.<tailnet>.ts.net`).
+1. Network extension installed and loaded:
 
 ```bash
-# Verify the MagicDNS name
-tailscale status --json | jq .Self.MagicDNSSuffix
+systemextensionsctl list | grep -i tailscale
+# Should show at least 1 Tailscale extension
+```
 
-# Fetch the certificates (substitute your own MagicDNS hostname)
+2. MagicDNS resolves to 100.x:
+
+```bash
+dig +short <your-machine>.<tailnet>.ts.net
+# Should return 100.x.x.x, not 209.x.x.x
+```
+
+If either check fails, use **Approach 2 (Funnel)** instead.
+
+### Steps
+
+```bash
+# Generate Tailscale TLS certs
 MAGICDNS="<your-machine>.<tailnet>.ts.net"
 mkdir -p ~/.openclaw/tls
 cd ~/.openclaw/tls
 tailscale cert "$MAGICDNS"
-
-# Rename them for convenience
 mv "$MAGICDNS.crt" server.crt
 mv "$MAGICDNS.key" server.key
+
+# Set up tailscale serve (proxy to loopback gateway)
+tailscale serve --bg --https=443 http://127.0.0.1:18789
 ```
 
-#### Apply Secure OpenClaw Settings
-
-Configure your `~/.openclaw/openclaw.json` (or use `openclaw config set`) with the
-following block under the `gateway` key. Replace `<your-machine>.<tailnet>.ts.net` with
-your MagicDNS hostname and `$HOME` with your actual home directory path:
+### Gateway Config
 
 ```json5
 "gateway": {
-  "port": 18789,
-  "mode": "local",
-  "bind": "tailnet",
+  "bind": "loopback",
   "auth": {
     "mode": "password",
-    "password": "<choose-a-strong-password>"
+    "password": "<choose-password>"
   },
   "tls": {
     "enabled": true,
-    "certPath": "$HOME/.openclaw/tls/server.crt",
-    "keyPath": "$HOME/.openclaw/tls/server.key"
+    "certPath": "/Users/<user>/.openclaw/tls/server.crt",
+    "keyPath": "/Users/<user>/.openclaw/tls/server.key"
   },
   "tailscale": {
     "mode": "off",
@@ -82,23 +78,174 @@ your MagicDNS hostname and `$HOME` with your actual home directory path:
   "controlUi": {
     "enabled": true,
     "allowedOrigins": [
-      // Allow only the specific MagicDNS name over HTTPS
-      "https://<your-machine>.<tailnet>.ts.net:18789"
+      "https://<your-machine>.<tailnet>.ts.net"
     ]
   }
 }
 ```
 
-Note: paths in `openclaw.json` must be absolute — `$HOME` above is shown for
-readability; substitute the expanded path (e.g., `/Users/you/.openclaw/tls/server.crt`)
-when saving.
+### Verify
 
-#### Access
+```bash
+tailscale serve status --json   # should show proxy config
+curl -sS https://<your-machine>.<tailnet>.ts.net/ | head -5  # HTTP 200
+```
 
-Your dashboard is now secured natively via HTTPS and can be accessed seamlessly over the
-Tailnet at:
+---
 
-**`https://<your-machine>.<tailnet>.ts.net:18789`**
+## Approach 2: Funnel (When Network Extension Is Missing)
 
-Use the configured password to authenticate. Device identity WebCrypto operations pass
-without error thanks to a native "Secure Context."
+Uses Tailscale's public proxy servers instead of local DNS interception. No network
+extension required.
+
+**Why network extensions go missing:** On macOS, the Tailscale app may be installed
+without the system extension (e.g. Mac App Store version, or the extension was removed
+in Privacy & Security settings). Without it, MagicDNS queries for `*.ts.net` fall
+through to the local resolver and return Tailscale's public ingress IPs (209.x) instead
+of the tailnet IP (100.x). `tailscale serve` can't intercept traffic that never reaches
+the local machine.
+
+**Check:** `systemextensionsctl list` — if it shows 0 Tailscale extensions, use this
+approach.
+
+### Steps
+
+```bash
+# Set up funnel (proxies through Tailscale's public servers)
+tailscale funnel --bg --https=443 http://127.0.0.1:18789
+```
+
+### Gateway Config
+
+```json5
+"gateway": {
+  "bind": "loopback",
+  "auth": {
+    "mode": "password",
+    "password": "<choose-password>"
+  },
+  "tailscale": {
+    "mode": "off",
+    "resetOnExit": false
+  },
+  "controlUi": {
+    "enabled": true,
+    "dangerouslyDisableDeviceAuth": true,
+    "allowedOrigins": [
+      "https://<your-machine>.<tailnet>.ts.net"
+    ]
+  }
+}
+```
+
+### Verify
+
+```bash
+tailscale funnel status --json   # should show AllowFunnel config
+curl -sS https://<your-machine>.<tailnet>.ts.net/ | head -5  # HTTP 200
+```
+
+---
+
+## Persistence Across Restarts
+
+`tailscale funnel --bg` persists in Tailscale's state and survives gateway restarts. It
+also survives reboots because Tailscale itself starts at login.
+
+No additional launchd agents are needed — Tailscale manages the funnel config
+internally.
+
+### Tailscale App Auto-Start
+
+Make sure Tailscale launches at login:
+
+```bash
+# Verify Tailscale is set to open at login
+osascript -e 'tell application "System Events" to get the name of every login item' | grep -i tailscale
+```
+
+If missing, add it via System Settings > General > Login Items, or:
+
+```bash
+osascript -e 'tell application "System Events" to make login item at end with properties {path:"/Applications/Tailscale.app", hidden:false}'
+```
+
+---
+
+## Troubleshooting
+
+### Serve config disappears immediately
+
+**Symptom:** `tailscale serve --bg` reports success, but `tailscale serve status --json`
+returns `{}` right after.
+
+**Cause:** Tailscale network extension is not installed. The serve config needs the
+network extension to route traffic through WireGuard. Without it, the daemon discards
+the config.
+
+**Fix:** Use `tailscale funnel` instead (Approach 2), or install the network extension.
+
+### Etag mismatch errors
+
+**Symptom:** `tailscale funnel` or `tailscale serve` returns "Another client is changing
+the serve config" or "preconditions failed: etag mismatch."
+
+**Cause:** Race condition between multiple Tailscale processes (CLI, app UI).
+
+**Fix:**
+
+```bash
+tailscale funnel reset
+tailscale serve reset
+sleep 2
+tailscale funnel --bg --https=443 http://127.0.0.1:18789
+```
+
+### DNS resolves to 209.x instead of 100.x
+
+**Symptom:** `dig +short <hostname>.ts.net` returns 209.177.x.x addresses.
+
+**Cause:** Tailscale network extension not intercepting DNS for `*.ts.net`.
+
+**Diagnose:**
+
+```bash
+# Check DNS config
+scutil --dns | grep -A3 tailscale
+# If "reach: 0x00000000 (Not Reachable)" — extension not loaded
+
+# Check Tailscale's DNS directly
+nslookup <hostname>.ts.net 100.100.100.100
+# If this returns 100.x — Tailscale DNS works, but macOS isn't using it
+```
+
+**Fix:** Use funnel (Approach 2), or install the network extension.
+
+### Gateway bind:loopback still listens on all interfaces
+
+**Symptom:** `lsof -Pn -i :18789` shows `*:18789` instead of `127.0.0.1:18789`.
+
+**Cause:** Gateway may need a full restart (not just SIGUSR1 reload) to rebind.
+
+**Fix:**
+
+```bash
+openclaw gateway restart
+sleep 3
+lsof -Pn -i :18789 | grep LISTEN
+# Should show 127.0.0.1:18789
+```
+
+---
+
+## Security Notes
+
+- **Loopback bind is mandatory.** Always bind the gateway to `loopback` so Tailscale is
+  the only way in. Never bind to `lan` or `tailnet` when using funnel.
+- **Password auth protects funnel access.** Even though funnel is public, the gateway
+  password (`million1` or stronger) is required.
+- **`dangerouslyDisableDeviceAuth`** is needed with funnel because the device identity
+  check relies on Web Crypto APIs that require a secure context with loopback bind. Keep
+  this true when using funnel; turn it off when using Approach 1 (Serve + TLS).
+- **Upgrade path:** When the Tailscale network extension is available, switch to
+  Approach 1 (Serve + TLS) and remove `dangerouslyDisableDeviceAuth`.

--- a/devops/tailscale-dns-troubleshooting.md
+++ b/devops/tailscale-dns-troubleshooting.md
@@ -32,6 +32,7 @@ Create a macOS resolver file that tells the system DNS to use Tailscale's namese
 `*.ts.net` queries:
 
 ```bash
+sudo mkdir -p /etc/resolver
 echo "nameserver 100.100.100.100" | sudo tee /etc/resolver/ts.net
 ```
 
@@ -69,8 +70,8 @@ python3 -c "import socket; print(socket.getaddrinfo('<hostname>.ts.net', 443)[0]
 # curl (uses system resolver)
 curl -sS --max-time 5 https://<hostname>.ts.net/ -o /dev/null -w "%{remote_ip}\n"
 
-# Node.js (uses system resolver)
-node -e "require('dns').resolve4('<hostname>.ts.net', (e,a) => console.log(a))"
+# Node.js (uses system resolver via getaddrinfo)
+node -e "require('dns').lookup('<hostname>.ts.net', (e,addr) => console.log(addr))"
 ```
 
 Expected: `100.x.x.x` (tailnet IP)

--- a/devops/tailscale-dns-troubleshooting.md
+++ b/devops/tailscale-dns-troubleshooting.md
@@ -1,0 +1,122 @@
+# Tailscale + macOS DNS Troubleshooting (Homebrew Install)
+
+## The Problem
+
+When Tailscale is installed via Homebrew (`brew install tailscale`), it uses the `utun`
+kernel interface instead of a macOS system/network extension. This works fine for VPN
+connectivity but **breaks DNS interception**.
+
+Without DNS interception, `*.ts.net` MagicDNS hostnames resolve to Tailscale's public
+ingress IPs (209.x) instead of tailnet IPs (100.x). This causes:
+
+- `tailscale serve` to silently discard its config (returns `{}` immediately)
+- `curl` or browsers get `SSL_ERROR_SYSCALL` or `ERR_CONNECTION_CLOSED`
+- `dig` and `nslookup` show the wrong IPs
+
+## Why It Happens
+
+On macOS, Tailscale has three installation variants:
+
+| Variant                | DNS Mechanism         | Install Method           |
+| ---------------------- | --------------------- | ------------------------ |
+| App Store / Standalone | Network Extension     | `.pkg` or App Store      |
+| Homebrew (headless)    | `utun` (no extension) | `brew install tailscale` |
+
+The network extension intercepts `*.ts.net` DNS queries and routes them to
+`100.100.100.100` (Tailscale's DNS). Without it, queries go to the system's default
+resolver (usually your router), which returns public IPs.
+
+## The Fix
+
+Create a macOS resolver file that tells the system DNS to use Tailscale's nameserver for
+`*.ts.net` queries:
+
+```bash
+echo "nameserver 100.100.100.100" | sudo tee /etc/resolver/ts.net
+```
+
+Flush DNS cache:
+
+```bash
+sudo dscacheutil -flushcache
+sudo killall -HUP mDNSResponder 2>/dev/null || true
+```
+
+### Where to Run This
+
+**On every machine** that needs to resolve `*.ts.net` hostnames:
+
+- The server hosting `tailscale serve`
+- Every client machine (laptop, desktop) that accesses the dashboard
+- Any machine running scripts that connect to `*.ts.net` URLs
+
+The server-side fix enables `tailscale serve` to persist. The client-side fix enables
+browsers and CLI tools to reach the dashboard.
+
+### Persistence
+
+`/etc/resolver/ts.net` survives reboots. No launchd agent or cron job needed.
+
+## How to Verify
+
+**Do NOT use `dig` or `nslookup`** — they bypass the macOS system resolver and always
+show the public IPs. Use tools that go through the system resolver:
+
+```bash
+# Python (uses system resolver)
+python3 -c "import socket; print(socket.getaddrinfo('<hostname>.ts.net', 443)[0][4][0])"
+
+# curl (uses system resolver)
+curl -sS --max-time 5 https://<hostname>.ts.net/ -o /dev/null -w "%{remote_ip}\n"
+
+# Node.js (uses system resolver)
+node -e "require('dns').resolve4('<hostname>.ts.net', (e,a) => console.log(a))"
+```
+
+Expected: `100.x.x.x` (tailnet IP)
+
+Wrong: `209.x.x.x` (public ingress IP)
+
+## Diagnosing
+
+Check if the resolver file is configured:
+
+```bash
+scutil --dns | grep -A3 'ts.net'
+```
+
+Expected output includes:
+
+```
+domain   : ts.net
+nameserver[0] : 100.100.100.100
+flags    : Request A records
+reach    : 0x00000002 (Reachable)
+```
+
+If `reach` shows `0x00000000 (Not Reachable)`, the file exists but Tailscale's DNS
+server isn't responding (check `tailscale status`).
+
+## Common Mistakes
+
+### Using `dig` to test DNS
+
+`dig` has its own DNS resolver stack and bypasses `/etc/resolver/`. It will always show
+the public IPs. This is expected and does NOT mean the fix is broken.
+
+### Setting up serve before the DNS fix
+
+If `tailscale serve --bg` reports success but `tailscale serve status --json` returns
+`{}`, the DNS fix is missing. Tailscale's daemon checks DNS resolution before committing
+the serve config.
+
+### Applying the fix on the server only
+
+Each machine that accesses the dashboard needs the fix. A laptop without
+`/etc/resolver/ts.net` will resolve to public IPs and get connection errors.
+
+## Related Docs
+
+- [Tailscale macOS Variants](https://tailscale.com/docs/concepts/macos-variants)
+- [Tailscale Serve](https://tailscale.com/kb/1312/serve)
+- [OpenClaw Dashboard Security](./tailscale-dashboard-security.md)


### PR DESCRIPTION
## Summary

- Rewrites Tailscale dashboard security doc with `tailscale serve` + `/etc/resolver` approach (replaces manual TLS cert management)
- Adds Tailscale DNS troubleshooting guide
- Updates machine-setup.md with Tailscale serve integration steps
- Removes tailnet-specific suffixes from example commands

## Test plan
- [x] PII scan clean — all generic placeholders
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)