### PR TITLE
feat: add apple-photos skill for macOS Photos library

### DIFF
--- a/skills/apple-photos/SKILL.md
+++ b/skills/apple-photos/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: apple-photos
+version: 0.1.0
+description:
+  Query, inspect, and export photos from the macOS Apple Photos library using osxphotos.
+  Find photos by person, album, keyword, or date range. Export candidates for curation
+  workflows.
+triggers:
+  - apple photos
+  - photos library
+  - find photos
+  - export photos
+  - photo of me
+  - photos of
+  - face clusters
+  - people in photos
+  - profile pictures
+metadata:
+  openclaw:
+    emoji: "\U0001F4F7"
+    platform: macos
+---
+
+# Apple Photos
+
+Query and export from the macOS Photos library. Three subcommands cover the typical
+workflow: discover people, search with filters, export to a folder.
+
+## Subcommands
+
+### people
+
+List face clusters with photo counts.
+
+```bash
+apple-photos people --limit 30
+apple-photos people --include-unknown
+```
+
+### query
+
+Search photos by person, album, keyword, and date range.
+
+```bash
+apple-photos query --person "<NAME>" --after 2026-01-01 --limit 20 --json
+apple-photos query --album "Favorites" --newest-first --limit 10
+apple-photos query --keyword "vacation" --before 2025-12-31
+```
+
+Filters: `--person`, `--album`, `--keyword`, `--after`, `--before`, `--favorite`,
+`--edited`, `--movies`, `--newest-first`
+
+### export
+
+Copy matched photos to a destination folder. Never modifies the Photos library.
+
+```bash
+apple-photos export ~/Desktop/exports --person "<NAME>" --after 2026-01-01 --limit 30
+apple-photos export ~/Desktop/exports --album "Favorites" --edited
+apple-photos export ~/Desktop/exports --person "<NAME>" --dry-run
+```
+
+Add `--edited` to prefer edited versions. Use `--dry-run` to preview without copying.
+
+## Workflow
+
+1. Run `people` to confirm the face label exists.
+2. Run `query` to search and preview matches.
+3. Run `export` to copy a batch to a working folder.
+4. Use vision or local tools to score, sort, crop, and retouch the exports.
+
+## Guardrails
+
+- Never modify the Photos library directly — export copies only.
+- Face labels can be incomplete. Spot-check results.
+- For large exports, start with `--dry-run` or a narrow date range.
+
+## Fallbacks
+
+- If face labels are incomplete, query by album/date and review manually.
+- If a photo only exists in Google Photos or shared links, use browser retrieval.
+- If the user wants deep retouching, export first, then use external editors.
+
+## Requirements
+
+- macOS with Photos.app
+- `osxphotos` Python library (auto-installed via UV on first run)

--- a/skills/apple-photos/apple-photos
+++ b/skills/apple-photos/apple-photos
@@ -118,8 +118,8 @@ def build_query_options(args: argparse.Namespace) -> QueryOptions:
         favorite=True if getattr(args, "favorite", False) else None,
         edited=True if getattr(args, "edited", False) else None,
         photos=True,
-        movies=getattr(args, "movies", True),
-        newest_first=getattr(args, "newest_first", True),
+        movies=getattr(args, "movies", False),
+        newest_first=getattr(args, "newest_first", False),
     )
 
 
@@ -228,6 +228,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_export.add_argument("--after", help="Photos on/after this date (YYYY-MM-DD)")
     p_export.add_argument("--before", help="Photos before this date (YYYY-MM-DD)")
     p_export.add_argument("--edited", action="store_true", help="Prefer edited versions")
+    p_export.add_argument("--movies", action="store_true", default=True, help="Include movies (default: on)")
+    p_export.add_argument("--newest-first", action="store_true", default=True, help="Sort newest first (default: on)")
     p_export.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
     p_export.add_argument("--dry-run", action="store_true")
 

--- a/skills/apple-photos/apple-photos
+++ b/skills/apple-photos/apple-photos
@@ -1,0 +1,254 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["osxphotos>=0.68"]
+# ///
+"""
+Apple Photos CLI - Query, inspect, and export photos from the macOS Photos library.
+
+Subcommands:
+  people   List face clusters / people with photo counts
+  query    Search photos by person, album, keyword, date range
+  export   Copy matched photos to a destination folder
+"""
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import shutil
+import sys
+
+from osxphotos import PhotosDB, QueryOptions
+
+DEFAULT_LIMIT = 50
+
+
+def parse_date(value: str | None) -> dt.datetime | None:
+    """Parse ISO date string (YYYY-MM-DD or full ISO) to datetime."""
+    if not value:
+        return None
+    return dt.datetime.fromisoformat(value)
+
+
+def get_db(library_path: str | None = None) -> PhotosDB:
+    """Open the Photos database, optionally at a specific library path."""
+    try:
+        return PhotosDB(library_path=library_path) if library_path else PhotosDB()
+    except Exception as exc:
+        path_hint = library_path or "default system library"
+        print(
+            f"ERROR: Could not open Photos library ({path_hint}): {exc}\n"
+            "Ensure Photos.app has been opened at least once on this Mac.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def sanitize_filename(name: str) -> str:
+    """Remove characters that are unsafe in filenames."""
+    return "".join(
+        c if c.isalnum() or c in (" ", "-", "_", ".", "(", ")") else "_"
+        for c in name
+    ).strip()
+
+
+def unique_path(dest: pathlib.Path, name: str) -> pathlib.Path:
+    """Return a non-colliding path, appending _1, _2, etc. if needed."""
+    candidate = dest / name
+    if not candidate.exists():
+        return candidate
+    stem = candidate.stem
+    suffix = candidate.suffix
+    counter = 1
+    while candidate.exists():
+        candidate = dest / f"{stem}_{counter}{suffix}"
+        counter += 1
+    return candidate
+
+
+def photo_to_dict(photo) -> dict:
+    """Convert a PhotoInfo object to a JSON-serializable dict."""
+    return {
+        "uuid": photo.uuid,
+        "filename": photo.filename,
+        "original_filename": photo.original_filename,
+        "date": photo.date.isoformat() if photo.date else None,
+        "original_path": photo.path,
+        "edited_path": photo.path_edited,
+        "persons": sorted(set(photo.persons or [])),
+        "albums": sorted(set(photo.albums or [])),
+        "favorite": bool(getattr(photo, "favorite", False)),
+        "hasadjustments": bool(getattr(photo, "hasadjustments", False)),
+        "ismissing": bool(getattr(photo, "ismissing", False)),
+    }
+
+
+# -- Subcommand: people -------------------------------------------------------
+
+
+def cmd_people(args: argparse.Namespace) -> None:
+    """List people / face clusters with photo counts."""
+    db = get_db(args.library)
+    people = []
+    counts = db.persons_as_dict
+    for name in db.persons:
+        if not args.include_unknown and name == "_UNKNOWN_":
+            continue
+        count_or_list = counts.get(name, [])
+        count = len(count_or_list) if isinstance(count_or_list, (list, tuple, set)) else int(count_or_list)
+        people.append((name, count))
+
+    people.sort(key=lambda x: (-x[1], x[0].lower()))
+    for name, count in people[: args.limit]:
+        print(f"{count}\t{name}")
+
+
+# -- Shared query builder -----------------------------------------------------
+
+
+def build_query_options(args: argparse.Namespace) -> QueryOptions:
+    """Build QueryOptions from parsed CLI arguments."""
+    return QueryOptions(
+        person=args.person or None,
+        album=args.album or None,
+        keyword=args.keyword or None,
+        from_date=parse_date(args.after),
+        to_date=parse_date(args.before),
+        favorite=True if getattr(args, "favorite", False) else None,
+        edited=True if getattr(args, "edited", False) else None,
+        photos=True,
+        movies=getattr(args, "movies", True),
+        newest_first=getattr(args, "newest_first", True),
+    )
+
+
+# -- Subcommand: query --------------------------------------------------------
+
+
+def cmd_query(args: argparse.Namespace) -> None:
+    """Query photos with filters and output results."""
+    db = get_db(args.library)
+    photos = db.query(build_query_options(args))
+    if args.limit:
+        photos = photos[: args.limit]
+
+    rows = [photo_to_dict(p) for p in photos]
+
+    if args.json:
+        print(json.dumps(rows, indent=2, ensure_ascii=False))
+    else:
+        for item in rows:
+            path = item["edited_path"] or item["original_path"]
+            print(f"{item['date']}\t{item['original_filename']}\t{path}")
+
+
+# -- Subcommand: export -------------------------------------------------------
+
+
+def cmd_export(args: argparse.Namespace) -> None:
+    """Export matched photos to a destination directory."""
+    db = get_db(args.library)
+    photos = db.query(build_query_options(args))
+    if args.limit:
+        photos = photos[: args.limit]
+
+    dest = pathlib.Path(args.dest).expanduser()
+    dest.mkdir(parents=True, exist_ok=True)
+
+    count = 0
+    skipped = 0
+    for photo in photos:
+        src = photo.path_edited if args.edited and photo.path_edited else photo.path
+        if not src:
+            continue
+        src_path = pathlib.Path(src)
+        if not src_path.exists():
+            continue
+        stamp = photo.date.strftime("%Y-%m-%d_%H%M%S") if photo.date else "undated"
+        out_name = sanitize_filename(f"{stamp}_{photo.original_filename}")
+        out_path = unique_path(dest, out_name)
+        if args.dry_run:
+            print(f"DRYRUN\t{src_path}\t{out_path}")
+        else:
+            try:
+                shutil.copy2(src_path, out_path)
+                print(f"COPIED\t{out_path}")
+            except OSError as exc:
+                print(f"SKIP\t{src_path}\t{exc}", file=sys.stderr)
+                skipped += 1
+                continue
+        count += 1
+
+    summary = f"Exported {count} item(s) to {dest}"
+    if skipped:
+        summary += f" ({skipped} skipped due to errors)"
+    print(summary)
+
+
+# -- Argument parser -----------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser with subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="apple-photos",
+        description="Query, inspect, and export photos from Apple Photos",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    # -- people --
+    p_people = sub.add_parser("people", help="List people / face clusters")
+    p_people.add_argument("--library", help="Path to Photos library")
+    p_people.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    p_people.add_argument("--include-unknown", action="store_true")
+
+    # -- query --
+    p_query = sub.add_parser("query", help="Query photos with filters")
+    p_query.add_argument("--library", help="Path to Photos library")
+    p_query.add_argument("--person", action="append", default=[], help="Person name (repeatable)")
+    p_query.add_argument("--album", action="append", default=[], help="Album name (repeatable)")
+    p_query.add_argument("--keyword", action="append", default=[], help="Keyword (repeatable)")
+    p_query.add_argument("--after", help="Photos on/after this date (YYYY-MM-DD)")
+    p_query.add_argument("--before", help="Photos before this date (YYYY-MM-DD)")
+    p_query.add_argument("--favorite", action="store_true")
+    p_query.add_argument("--edited", action="store_true")
+    p_query.add_argument("--movies", action="store_true", help="Include movies")
+    p_query.add_argument("--newest-first", action="store_true")
+    p_query.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    p_query.add_argument("--json", action="store_true")
+
+    # -- export --
+    p_export = sub.add_parser("export", help="Export matched photos to a folder")
+    p_export.add_argument("dest", help="Destination directory")
+    p_export.add_argument("--library", help="Path to Photos library")
+    p_export.add_argument("--person", action="append", default=[], help="Person name (repeatable)")
+    p_export.add_argument("--album", action="append", default=[], help="Album name (repeatable)")
+    p_export.add_argument("--keyword", action="append", default=[], help="Keyword (repeatable)")
+    p_export.add_argument("--after", help="Photos on/after this date (YYYY-MM-DD)")
+    p_export.add_argument("--before", help="Photos before this date (YYYY-MM-DD)")
+    p_export.add_argument("--edited", action="store_true", help="Prefer edited versions")
+    p_export.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    p_export.add_argument("--dry-run", action="store_true")
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    commands = {
+        "people": cmd_people,
+        "query": cmd_query,
+        "export": cmd_export,
+    }
+    commands[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/apple-photos/recipes.md
+++ b/skills/apple-photos/recipes.md
@@ -1,0 +1,58 @@
+# Apple Photos recipes
+
+## Installed toolchain
+
+- `osxphotos`: Python library (auto-installed via UV script)
+- `exiftool`: useful for EXIF inspection after export
+- `sqlite3`: direct Photos.db access (rarely needed)
+
+## Common commands
+
+### List libraries
+
+```bash
+osxphotos list
+```
+
+### Show active library info
+
+```bash
+osxphotos info
+```
+
+### List people
+
+```bash
+apple-photos people --limit 100
+```
+
+### Query recent photos of a person
+
+```bash
+apple-photos query --person "<NAME>" --after 2026-01-01 --limit 100 --json
+```
+
+### Export recent photos of a person
+
+```bash
+apple-photos export ~/Desktop/exports --person "<NAME>" --after 2026-01-01 --limit 50
+```
+
+### Export from an album
+
+```bash
+apple-photos export ~/Desktop/exports --album "Favorites" --limit 50
+```
+
+### Dry-run export to preview
+
+```bash
+apple-photos export ~/Desktop/exports --person "<NAME>" --after 2025-06-01 --dry-run
+```
+
+## Notes
+
+- The Python API (`osxphotos.PhotosDB`) is more reliable than `osxphotos query --json`,
+  which can error on some CLI theme/config combinations.
+- `osxphotos persons` and `osxphotos query --count` still work for spot checks.
+- Export copies files out of the library — it never mutates Photos.app.

--- a/tests/test_apple_photos.py
+++ b/tests/test_apple_photos.py
@@ -1,0 +1,540 @@
+"""Tests for Apple Photos skill.
+
+Unit tests mock osxphotos to verify CLI logic without a Photos library.
+Integration tests require macOS with Photos.app and osxphotos installed.
+"""
+
+import datetime as dt
+import importlib.machinery
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SKILL_PATH = Path(__file__).parent / ".." / "skills" / "apple-photos" / "apple-photos"
+
+# Pre-register a mock osxphotos so the import doesn't fail on non-macOS/CI
+_mock_osxphotos = MagicMock()
+_mock_osxphotos.QueryOptions = MagicMock
+sys.modules.setdefault("osxphotos", _mock_osxphotos)
+
+# Dynamically load the skill script as a module (no .py extension)
+_loader = importlib.machinery.SourceFileLoader("apple_photos", str(SKILL_PATH))
+spec = importlib.util.spec_from_loader("apple_photos", _loader)
+apple_photos = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(apple_photos)
+
+try:
+    import osxphotos as _real_osxphotos  # noqa: F401
+
+    HAS_OSXPHOTOS = True
+except ImportError:
+    HAS_OSXPHOTOS = False
+
+HAS_PHOTOS_LIBRARY = HAS_OSXPHOTOS and sys.platform == "darwin"
+
+requires_osxphotos = pytest.mark.skipif(
+    not HAS_OSXPHOTOS,
+    reason="osxphotos not installed",
+)
+
+requires_photos_library = pytest.mark.skipif(
+    not HAS_PHOTOS_LIBRARY,
+    reason="No macOS Photos library available",
+)
+
+
+# -- Fixtures ------------------------------------------------------------------
+
+
+def make_mock_photo(
+    uuid="ABC-123",
+    filename="IMG_1234.HEIC",
+    original_filename="IMG_1234.HEIC",
+    date=None,
+    path="/photos/IMG_1234.HEIC",
+    path_edited=None,
+    persons=None,
+    albums=None,
+    favorite=False,
+    hasadjustments=False,
+    ismissing=False,
+):
+    """Create a mock PhotoInfo object."""
+    photo = MagicMock()
+    photo.uuid = uuid
+    photo.filename = filename
+    photo.original_filename = original_filename
+    photo.date = date or dt.datetime(2026, 3, 15, 10, 30, 0)  # noqa: DTZ001
+    photo.path = path
+    photo.path_edited = path_edited
+    photo.persons = persons or []
+    photo.albums = albums or []
+    photo.favorite = favorite
+    photo.hasadjustments = hasadjustments
+    photo.ismissing = ismissing
+    return photo
+
+
+# -- Unit tests: pure functions ------------------------------------------------
+
+
+class TestParseDate:
+    """Tests for date parsing."""
+
+    def test_none_returns_none(self):
+        assert apple_photos.parse_date(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert apple_photos.parse_date("") is None
+
+    def test_date_only(self):
+        result = apple_photos.parse_date("2026-03-15")
+        assert result == dt.datetime(2026, 3, 15)  # noqa: DTZ001
+
+    def test_full_iso(self):
+        result = apple_photos.parse_date("2026-03-15T10:30:00")
+        assert result == dt.datetime(2026, 3, 15, 10, 30, 0)  # noqa: DTZ001
+
+    def test_invalid_date_raises(self):
+        with pytest.raises(ValueError):
+            apple_photos.parse_date("not-a-date")
+
+
+class TestSanitizeFilename:
+    """Tests for filename sanitization."""
+
+    def test_simple_name_unchanged(self):
+        assert apple_photos.sanitize_filename("IMG_1234.HEIC") == "IMG_1234.HEIC"
+
+    def test_preserves_safe_chars(self):
+        assert (
+            apple_photos.sanitize_filename("2026-03-15_photo (1).jpg")
+            == "2026-03-15_photo (1).jpg"
+        )
+
+    def test_replaces_slashes(self):
+        result = apple_photos.sanitize_filename("path/to/file.jpg")
+        assert "/" not in result
+
+    def test_replaces_special_chars(self):
+        result = apple_photos.sanitize_filename("photo@#$%!.jpg")
+        assert "@" not in result
+        assert "#" not in result
+
+    def test_strips_whitespace(self):
+        result = apple_photos.sanitize_filename("  photo.jpg  ")
+        assert result == "photo.jpg"
+
+
+class TestPhotoToDict:
+    """Tests for photo-to-dict conversion."""
+
+    def test_basic_conversion(self):
+        photo = make_mock_photo(
+            uuid="ABC-123",
+            filename="IMG_1234.HEIC",
+            persons=["Alice", "Bob"],
+            albums=["Vacation"],
+        )
+        result = apple_photos.photo_to_dict(photo)
+        assert result["uuid"] == "ABC-123"
+        assert result["filename"] == "IMG_1234.HEIC"
+        assert result["persons"] == ["Alice", "Bob"]
+        assert result["albums"] == ["Vacation"]
+        assert result["date"] == "2026-03-15T10:30:00"
+
+    def test_both_paths_present(self):
+        photo = make_mock_photo(
+            path="/photos/original.heic",
+            path_edited="/photos/edited.heic",
+        )
+        result = apple_photos.photo_to_dict(photo)
+        assert result["original_path"] == "/photos/original.heic"
+        assert result["edited_path"] == "/photos/edited.heic"
+
+    def test_no_edited_path(self):
+        photo = make_mock_photo(path="/photos/original.heic", path_edited=None)
+        result = apple_photos.photo_to_dict(photo)
+        assert result["original_path"] == "/photos/original.heic"
+        assert result["edited_path"] is None
+
+    def test_none_date(self):
+        photo = make_mock_photo()
+        photo.date = None
+        result = apple_photos.photo_to_dict(photo)
+        assert result["date"] is None
+
+    def test_deduplicates_persons(self):
+        photo = make_mock_photo(persons=["Alice", "Alice", "Bob"])
+        result = apple_photos.photo_to_dict(photo)
+        assert result["persons"] == ["Alice", "Bob"]
+
+    def test_sorts_albums(self):
+        photo = make_mock_photo(albums=["Zebra", "Alpha"])
+        result = apple_photos.photo_to_dict(photo)
+        assert result["albums"] == ["Alpha", "Zebra"]
+
+
+class TestUniquePath:
+    """Tests for collision-safe path generation."""
+
+    def test_no_collision(self, tmp_path):
+        result = apple_photos.unique_path(tmp_path, "photo.jpg")
+        assert result == tmp_path / "photo.jpg"
+
+    def test_collision_appends_counter(self, tmp_path):
+        (tmp_path / "photo.jpg").write_text("existing")
+        result = apple_photos.unique_path(tmp_path, "photo.jpg")
+        assert result == tmp_path / "photo_1.jpg"
+
+    def test_multiple_collisions(self, tmp_path):
+        (tmp_path / "photo.jpg").write_text("existing")
+        (tmp_path / "photo_1.jpg").write_text("existing")
+        result = apple_photos.unique_path(tmp_path, "photo.jpg")
+        assert result == tmp_path / "photo_2.jpg"
+
+
+# -- Unit tests: argparser -----------------------------------------------------
+
+
+class TestParser:
+    """Tests for argument parser construction."""
+
+    def test_parser_builds(self):
+        parser = apple_photos.build_parser()
+        assert parser is not None
+
+    def test_people_subcommand(self):
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["people", "--limit", "10"])
+        assert args.command == "people"
+        assert args.limit == 10
+
+    def test_query_subcommand(self):
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(
+            [
+                "query",
+                "--person",
+                "Alice",
+                "--after",
+                "2026-01-01",
+                "--json",
+            ]
+        )
+        assert args.command == "query"
+        assert args.person == ["Alice"]
+        assert args.after == "2026-01-01"
+        assert args.json is True
+
+    def test_query_multiple_persons(self):
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(
+            [
+                "query",
+                "--person",
+                "Alice",
+                "--person",
+                "Bob",
+            ]
+        )
+        assert args.person == ["Alice", "Bob"]
+
+    def test_export_subcommand(self):
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(
+            [
+                "export",
+                "/Users/test/out",
+                "--person",
+                "Alice",
+                "--dry-run",
+            ]
+        )
+        assert args.command == "export"
+        assert args.dest == "/Users/test/out"
+        assert args.dry_run is True
+
+    def test_no_subcommand_exits(self):
+        parser = apple_photos.build_parser()
+        args = parser.parse_args([])
+        assert args.command is None
+
+
+# -- Unit tests: subcommand logic with mocked DB ------------------------------
+
+
+class TestCmdPeople:
+    """Tests for the people subcommand with mocked PhotosDB."""
+
+    def test_lists_people_sorted_by_count(self, capsys):
+        mock_db = MagicMock()
+        mock_db.persons = ["Alice", "Bob", "_UNKNOWN_"]
+        mock_db.persons_as_dict = {
+            "Alice": ["p1", "p2", "p3"],
+            "Bob": ["p1"],
+            "_UNKNOWN_": ["p1", "p2"],
+        }
+
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["people", "--limit", "10"])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_people(args)
+
+        output = capsys.readouterr().out
+        lines = output.strip().split("\n")
+        assert len(lines) == 2  # _UNKNOWN_ excluded
+        assert lines[0].startswith("3\t")
+        assert "Alice" in lines[0]
+        assert lines[1].startswith("1\t")
+        assert "Bob" in lines[1]
+
+    def test_includes_unknown_when_flagged(self, capsys):
+        mock_db = MagicMock()
+        mock_db.persons = ["Alice", "_UNKNOWN_"]
+        mock_db.persons_as_dict = {
+            "Alice": ["p1"],
+            "_UNKNOWN_": ["p1", "p2"],
+        }
+
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["people", "--include-unknown"])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_people(args)
+
+        output = capsys.readouterr().out
+        assert "_UNKNOWN_" in output
+
+
+class TestCmdQuery:
+    """Tests for the query subcommand with mocked PhotosDB."""
+
+    def test_json_output(self, capsys):
+        mock_db = MagicMock()
+        mock_db.query.return_value = [
+            make_mock_photo(uuid="1", filename="a.jpg"),
+            make_mock_photo(uuid="2", filename="b.jpg"),
+        ]
+
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["query", "--json", "--limit", "10"])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_query(args)
+
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert len(data) == 2
+        assert data[0]["uuid"] == "1"
+
+    def test_text_output(self, capsys):
+        mock_db = MagicMock()
+        mock_db.query.return_value = [
+            make_mock_photo(filename="photo.jpg", path="/photos/photo.jpg"),
+        ]
+
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["query"])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_query(args)
+
+        output = capsys.readouterr().out
+        assert "photo.jpg" in output
+        assert "\t" in output
+
+    def test_limit_applied(self, capsys):
+        mock_db = MagicMock()
+        mock_db.query.return_value = [make_mock_photo(uuid=str(i)) for i in range(10)]
+
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["query", "--json", "--limit", "3"])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_query(args)
+
+        data = json.loads(capsys.readouterr().out)
+        assert len(data) == 3
+
+
+class TestCmdExport:
+    """Tests for the export subcommand with mocked PhotosDB."""
+
+    def test_dry_run_no_copy(self, capsys, tmp_path):
+        mock_photo = make_mock_photo(
+            path=str(tmp_path / "source.jpg"),
+            original_filename="source.jpg",
+        )
+        # Create the source file so the exists() check passes
+        (tmp_path / "source.jpg").write_text("fake image data")
+
+        mock_db = MagicMock()
+        mock_db.query.return_value = [mock_photo]
+
+        dest = tmp_path / "output"
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["export", str(dest), "--dry-run"])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_export(args)
+
+        output = capsys.readouterr().out
+        assert "DRYRUN" in output
+        assert "Exported 1 item(s)" in output
+        # Dest dir is created but no files copied
+        assert dest.exists()
+        assert not list(dest.glob("*"))
+
+    def test_actual_copy(self, capsys, tmp_path):
+        source_file = tmp_path / "source.jpg"
+        source_file.write_text("fake image data")
+
+        mock_photo = make_mock_photo(
+            path=str(source_file),
+            original_filename="source.jpg",
+        )
+
+        mock_db = MagicMock()
+        mock_db.query.return_value = [mock_photo]
+
+        dest = tmp_path / "output"
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["export", str(dest)])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_export(args)
+
+        output = capsys.readouterr().out
+        assert "COPIED" in output
+        assert "Exported 1 item(s)" in output
+        exported = list(dest.glob("*"))
+        assert len(exported) == 1
+        assert exported[0].read_text() == "fake image data"
+
+    def test_skips_missing_source(self, capsys, tmp_path):
+        mock_photo = make_mock_photo(
+            path="/nonexistent/photo.jpg",
+            original_filename="photo.jpg",
+        )
+
+        mock_db = MagicMock()
+        mock_db.query.return_value = [mock_photo]
+
+        dest = tmp_path / "output"
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["export", str(dest)])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_export(args)
+
+        output = capsys.readouterr().out
+        assert "Exported 0 item(s)" in output
+
+    def test_filename_collision_appends_suffix(self, capsys, tmp_path):
+        source1 = tmp_path / "source1.jpg"
+        source2 = tmp_path / "source2.jpg"
+        source1.write_text("first photo")
+        source2.write_text("second photo")
+
+        same_date = dt.datetime(2026, 3, 15, 10, 30, 0)  # noqa: DTZ001
+        mock_photos = [
+            make_mock_photo(
+                path=str(source1), original_filename="IMG.jpg", date=same_date
+            ),
+            make_mock_photo(
+                path=str(source2), original_filename="IMG.jpg", date=same_date
+            ),
+        ]
+
+        mock_db = MagicMock()
+        mock_db.query.return_value = mock_photos
+
+        dest = tmp_path / "output"
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["export", str(dest)])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_export(args)
+
+        exported = sorted(dest.glob("*"))
+        assert len(exported) == 2
+        contents = {f.read_text() for f in exported}
+        assert contents == {"first photo", "second photo"}
+
+    def test_prefers_edited_when_flagged(self, capsys, tmp_path):
+        original = tmp_path / "original.jpg"
+        edited = tmp_path / "edited.jpg"
+        original.write_text("original")
+        edited.write_text("edited version")
+
+        mock_photo = make_mock_photo(
+            path=str(original),
+            path_edited=str(edited),
+            original_filename="photo.jpg",
+        )
+
+        mock_db = MagicMock()
+        mock_db.query.return_value = [mock_photo]
+
+        dest = tmp_path / "output"
+        parser = apple_photos.build_parser()
+        args = parser.parse_args(["export", str(dest), "--edited"])
+
+        with patch.object(apple_photos, "get_db", return_value=mock_db):
+            apple_photos.cmd_export(args)
+
+        exported = list(dest.glob("*"))
+        assert len(exported) == 1
+        assert exported[0].read_text() == "edited version"
+
+
+# -- Integration tests ---------------------------------------------------------
+
+
+@requires_photos_library
+class TestIntegrationPeople:
+    """Integration tests that run against a real Photos library."""
+
+    def test_people_runs(self):
+        result = subprocess.run(
+            [sys.executable, str(SKILL_PATH), "people", "--limit", "5"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+
+    def test_people_output_has_tabs(self):
+        result = subprocess.run(
+            [sys.executable, str(SKILL_PATH), "people", "--limit", "3"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.stdout.strip():
+            for line in result.stdout.strip().split("\n"):
+                assert "\t" in line
+
+
+@requires_photos_library
+class TestIntegrationQuery:
+    """Integration tests for query subcommand."""
+
+    def test_query_json_is_valid(self):
+        result = subprocess.run(
+            [sys.executable, str(SKILL_PATH), "query", "--limit", "2", "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+        if result.stdout.strip():
+            data = json.loads(result.stdout)
+            assert isinstance(data, list)

--- a/tests/test_apple_photos.py
+++ b/tests/test_apple_photos.py
@@ -17,7 +17,12 @@ import pytest
 
 SKILL_PATH = Path(__file__).parent / ".." / "skills" / "apple-photos" / "apple-photos"
 
-# Pre-register a mock osxphotos so the import doesn't fail on non-macOS/CI
+# Check real package availability BEFORE injecting the mock — find_spec doesn't import.
+HAS_OSXPHOTOS = importlib.util.find_spec("osxphotos") is not None
+HAS_PHOTOS_LIBRARY = HAS_OSXPHOTOS and sys.platform == "darwin"
+
+# Pre-register a mock so the skill script can be imported on non-macOS/CI.
+# setdefault preserves the real package if it's already been imported.
 _mock_osxphotos = MagicMock()
 _mock_osxphotos.QueryOptions = MagicMock
 sys.modules.setdefault("osxphotos", _mock_osxphotos)
@@ -27,15 +32,6 @@ _loader = importlib.machinery.SourceFileLoader("apple_photos", str(SKILL_PATH))
 spec = importlib.util.spec_from_loader("apple_photos", _loader)
 apple_photos = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(apple_photos)
-
-try:
-    import osxphotos as _real_osxphotos  # noqa: F401
-
-    HAS_OSXPHOTOS = True
-except ImportError:
-    HAS_OSXPHOTOS = False
-
-HAS_PHOTOS_LIBRARY = HAS_OSXPHOTOS and sys.platform == "darwin"
 
 requires_osxphotos = pytest.mark.skipif(
     not HAS_OSXPHOTOS,


### PR DESCRIPTION
## Summary

- Adds new `apple-photos` skill — single UV script with `people`, `query`, and `export` subcommands wrapping `osxphotos`
- Consolidates raw prototype (3 separate scripts from live instance) into repo-convention single executable
- 38 tests (unit with mocked PhotosDB + integration against real Photos library)

## What changed from the prototype

- **Collision-safe exports** — appends `_1`, `_2` suffixes instead of silently overwriting
- **Safe default limit** — export defaults to 50 (was unbounded 0)
- **Shared query builder** — `build_query_options` used by both query and export (was duplicated)
- **Per-file error handling** — `shutil.copy2` failures skip with report instead of killing the run
- **Actionable PhotosDB errors** — wraps init with clear error message
- **Removed ambiguous `path` field** — `photo_to_dict` now has `original_path`/`edited_path` only
- **Python >=3.13** — matches repo convention
- **No PII** — all examples use `<NAME>` placeholders

## Test plan

- [x] 38 pytest tests pass (unit + integration)
- [x] Pre-commit hooks pass (ruff, prettier, etc.)
- [x] Multi-agent code review (logic, robustness, style) — all findings addressed
- [x] Integration tests verified against real Photos library on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)