### PR TITLE
docs: switch Cortex rollout to local memory root backup

### DIFF
--- a/docs/librarian-to-cortex-migration.md
+++ b/docs/librarian-to-cortex-migration.md
@@ -1,67 +1,80 @@
 # Librarian to Cortex Migration Guide
 
-Status: verified on Hex, updated after rollout correction | Date: 2026-04-19
+Status: rollout pattern verified, updated after rollout correction | Date: 2026-04-19
 
 ## Purpose
 
-This guide documents the migration from the deprecated `librarian` skill to `cortex`, including the machine rollout process used on Hex.
+This guide documents the migration from the deprecated `librarian` skill to `cortex`,
+including the tested rollout process.
 
 ## Executive Summary
 
-Librarian was a conversation-memory organizer that curated `memory/` and trimmed `MEMORY.md`.
+Librarian was a conversation-memory organizer that curated `memory/` and trimmed
+`MEMORY.md`.
 
 Cortex is a broader knowledge compiler. It owns:
+
 - compiled knowledge storage
 - memory routing/index maintenance
 - ingest planning and state tracking
 - linting and cross-link stitching
 - learning analysis
 
-This is not just a skill swap. It is a shift from local markdown curation to a unified compiled knowledge system, with the root of `~/.openclaw/memory` as the source of truth.
+This is not just a skill swap. It is a shift from local markdown curation to a unified
+compiled knowledge system, with the root of `~/.openclaw/memory` as the source of truth.
 
 ## Architecture Shift
 
 ### Before: Librarian
 
 Primary responsibilities:
+
 - promote durable facts out of `memory/YYYY-MM-DD.md`
 - update `memory/people/`, `projects/`, `topics/`, `decisions/`
 - trim `MEMORY.md`
 - maintain lightweight memory hygiene
 
 Primary storage:
+
 - local `memory/` tree inside the OpenClaw workspace
 
 ### After: Cortex
 
 Primary responsibilities:
+
 - maintain a dedicated knowledge store in Dropbox-backed storage
 - compile raw sources into structured knowledge pages
-- track ingest state in SQLite (`.cortex.db`)
+- track ingest state in SQLite (`cortex.db`)
 - maintain a thin memory routing layer for agent discovery
 - replace librarian-triggered maintenance flows
 
 Primary storage:
+
 - the root of `~/.openclaw/memory/`
-- optional Dropbox backup copied on a schedule to `~/Dropbox/Knowledge Base - <agentname>/`
+- optional Dropbox backup copied on a schedule to
+  `~/Dropbox/Knowledge Base - <agentname>/`
 
 ## Important Design Decision
 
 Do not reuse a shared `Knowledge Base` directory when multiple assistants exist.
 
-For Hex, the corrected configuration is:
-- primary store: `~/.openclaw/memory/`
-- backup target: `~/Dropbox/Knowledge Base - Hex/`
+The corrected configuration is:
 
-This avoids relying on a memory symlink pattern that was determined not to work well, while still giving each assistant its own backup target.
+- primary store: `~/.openclaw/memory/`
+- backup target: `~/Dropbox/Knowledge Base - <agentname>/`
+
+This avoids relying on a memory symlink pattern that was determined not to work well,
+while still giving each assistant its own backup target.
 
 ## Current Cortex Behavior
 
 The current Cortex v2 implementation:
+
 - uses SQLite for ingest state
 - does not require a `raw/` directory
 - does not use lock files
-- still contains a symlink-oriented `cortex link` flow in the CLI, but this rollout should not use it
+- still contains a symlink-oriented `cortex link` flow in the CLI, but this rollout
+  should not use it
 - absorbs librarian functionality
 
 ## Machine Rollout Checklist
@@ -71,6 +84,7 @@ Use this sequence on each machine.
 ### 1. Update the repo
 
 Pull latest `openclaw-config` and confirm:
+
 - `skills/cortex/` exists
 - `skills/librarian/` is marked deprecated
 - docs reflect the current migration model
@@ -79,8 +93,9 @@ Pull latest `openclaw-config` and confirm:
 
 Pick a unique Dropbox backup target per assistant.
 
-Example for Hex:
-- backup target directory: `Knowledge Base - Hex`
+Example:
+
+- backup target directory: `Knowledge Base - <agentname>`
 
 ### 3. Use the local memory root as the primary store
 
@@ -91,11 +106,28 @@ Cortex content should live directly under:
 ```
 
 Expected outcomes:
-- `schema.md`, `.cortex.db`, indexes, and content live directly in the memory root
+
+- `schema.md`, `cortex.db`, indexes, and content live directly in the memory root
 - `MEMORY.md` stays alongside the Cortex files
 - no symlink is involved
 
-### 4. Bulk discovery and ingest preparation
+### 4. Create Cortex config
+
+Before running any Cortex CLI commands, create `~/.config/cortex/config` so `scan`,
+`triage`, `plan`, and `status` know where the local store lives.
+
+Example:
+
+```bash
+mkdir -p ~/.config/cortex
+printf '%s\n' \
+  "CORTEX_STORE_PATH=$HOME/.openclaw/memory" \
+  "CLOUD_PROVIDER=Dropbox" \
+  "CORTEX_BACKUP_PATH=$HOME/Dropbox/Knowledge Base - <agentname>" \
+  > ~/.config/cortex/config
+```
+
+### 5. Bulk discovery and ingest preparation
 
 Example:
 
@@ -107,15 +139,16 @@ Example:
 
 Do not run `cortex link` yet if bulk ingest is still pending.
 
-### 5. Backup after ingest
+### 6. Backup after ingest
 
 When initial ingest is done, copy the local memory root to Dropbox:
 
 ```bash
-rsync -a --delete ~/.openclaw/memory/ ~/Dropbox/"Knowledge Base - Hex"/
+rsync -a --delete ~/.openclaw/memory/ ~/Dropbox/"Knowledge Base - <agentname>"/
 ```
 
 Expected outcomes:
+
 - Dropbox receives a backup copy of the local memory root
 - agents continue reading and writing locally in `~/.openclaw/memory`
 - no symlink dependency exists in the runtime path
@@ -125,6 +158,7 @@ Expected outcomes:
 Do not perform a destructive migration of legacy memory files.
 
 Preserve these as historical context:
+
 - `memory/YYYY-MM-DD.md`
 - `memory/people/`
 - `memory/projects/`
@@ -133,6 +167,7 @@ Preserve these as historical context:
 - `memory/learning/`
 
 Going forward:
+
 - new compiled knowledge belongs in Cortex
 - `MEMORY.md` should become a routing layer, not the primary long-form store
 - legacy librarian-style curation should phase out
@@ -153,7 +188,7 @@ After rollout, verify all of the following:
 - [ ] `~/.config/cortex/config` exists
 - [ ] primary store exists directly in `~/.openclaw/memory/`
 - [ ] Dropbox backup target exists
-- [ ] `.cortex.db` exists
+- [ ] `cortex.db` exists
 - [ ] `schema.md` exists
 - [ ] `cortex status` succeeds against the local memory root
 - [ ] no runtime dependency on symlinked memory paths remains
@@ -163,40 +198,52 @@ After rollout, verify all of the following:
 ## Known Risks
 
 ### Split-brain memory
+
 Operators may continue treating `memory/` as the primary long-term knowledge store.
 
 Mitigation:
+
 - document Cortex as the new source of truth for compiled knowledge
 - keep `MEMORY.md` thin and pointer-oriented
 
 ### Namespace collisions
+
 Multiple assistants sharing `Knowledge Base` causes confusion and ownership ambiguity.
 
 Mitigation:
-- use assistant-specific names like `Knowledge Base - Hex`
+
+- use assistant-specific names like `Knowledge Base - <agentname>`
 
 ### Symlinked runtime storage
+
 Using a symlinked runtime memory store proved unreliable in practice.
 
 Mitigation:
+
 - keep runtime state local under `~/.openclaw/memory`
 - use Dropbox as backup only
 
 ### Doc drift
+
 Older design docs may still describe superseded v1 behavior.
 
 Mitigation:
+
 - treat `skills/cortex/SKILL.md` and the CLI behavior as the operational source of truth
 - update migration docs whenever rollout practice changes
 
-## Verified Hex Notes
+## Rollout Notes
 
-On Hex, rollout guidance was corrected after testing:
+Rollout guidance was corrected after testing:
+
 - symlinking the runtime memory store to Dropbox was not the right model
-- the correct pattern is local primary storage under `~/.openclaw/memory`, with Dropbox backup every 3 hours
+- the correct pattern is local primary storage under `~/.openclaw/memory`, with Dropbox
+  backup every 3 hours
 
-Hex now uses:
+Recommended rollout pattern:
+
 - local primary store: `~/.openclaw/memory/`
-- Dropbox backup target: `~/Dropbox/Knowledge Base - Hex/`
+- Dropbox backup target: `~/Dropbox/Knowledge Base - <agentname>/`
 
-This is the recommended pattern for future multi-assistant rollouts unless a stronger storage model is introduced.
+This is the recommended pattern for future multi-assistant rollouts unless a stronger
+storage model is introduced.

--- a/docs/librarian-to-cortex-migration.md
+++ b/docs/librarian-to-cortex-migration.md
@@ -1,0 +1,202 @@
+# Librarian to Cortex Migration Guide
+
+Status: verified on Hex, updated after rollout correction | Date: 2026-04-19
+
+## Purpose
+
+This guide documents the migration from the deprecated `librarian` skill to `cortex`, including the machine rollout process used on Hex.
+
+## Executive Summary
+
+Librarian was a conversation-memory organizer that curated `memory/` and trimmed `MEMORY.md`.
+
+Cortex is a broader knowledge compiler. It owns:
+- compiled knowledge storage
+- memory routing/index maintenance
+- ingest planning and state tracking
+- linting and cross-link stitching
+- learning analysis
+
+This is not just a skill swap. It is a shift from local markdown curation to a unified compiled knowledge system, with the root of `~/.openclaw/memory` as the source of truth.
+
+## Architecture Shift
+
+### Before: Librarian
+
+Primary responsibilities:
+- promote durable facts out of `memory/YYYY-MM-DD.md`
+- update `memory/people/`, `projects/`, `topics/`, `decisions/`
+- trim `MEMORY.md`
+- maintain lightweight memory hygiene
+
+Primary storage:
+- local `memory/` tree inside the OpenClaw workspace
+
+### After: Cortex
+
+Primary responsibilities:
+- maintain a dedicated knowledge store in Dropbox-backed storage
+- compile raw sources into structured knowledge pages
+- track ingest state in SQLite (`.cortex.db`)
+- maintain a thin memory routing layer for agent discovery
+- replace librarian-triggered maintenance flows
+
+Primary storage:
+- the root of `~/.openclaw/memory/`
+- optional Dropbox backup copied on a schedule to `~/Dropbox/Knowledge Base - <agentname>/`
+
+## Important Design Decision
+
+Do not reuse a shared `Knowledge Base` directory when multiple assistants exist.
+
+For Hex, the corrected configuration is:
+- primary store: `~/.openclaw/memory/`
+- backup target: `~/Dropbox/Knowledge Base - Hex/`
+
+This avoids relying on a memory symlink pattern that was determined not to work well, while still giving each assistant its own backup target.
+
+## Current Cortex Behavior
+
+The current Cortex v2 implementation:
+- uses SQLite for ingest state
+- does not require a `raw/` directory
+- does not use lock files
+- still contains a symlink-oriented `cortex link` flow in the CLI, but this rollout should not use it
+- absorbs librarian functionality
+
+## Machine Rollout Checklist
+
+Use this sequence on each machine.
+
+### 1. Update the repo
+
+Pull latest `openclaw-config` and confirm:
+- `skills/cortex/` exists
+- `skills/librarian/` is marked deprecated
+- docs reflect the current migration model
+
+### 2. Choose the backup target name
+
+Pick a unique Dropbox backup target per assistant.
+
+Example for Hex:
+- backup target directory: `Knowledge Base - Hex`
+
+### 3. Use the local memory root as the primary store
+
+Cortex content should live directly under:
+
+```bash
+~/.openclaw/memory/
+```
+
+Expected outcomes:
+- `schema.md`, `.cortex.db`, indexes, and content live directly in the memory root
+- `MEMORY.md` stays alongside the Cortex files
+- no symlink is involved
+
+### 4. Bulk discovery and ingest preparation
+
+Example:
+
+```bash
+~/src/openclaw-config/skills/cortex/cortex scan ~/Dropbox
+~/src/openclaw-config/skills/cortex/cortex triage
+~/src/openclaw-config/skills/cortex/cortex plan
+```
+
+Do not run `cortex link` yet if bulk ingest is still pending.
+
+### 5. Backup after ingest
+
+When initial ingest is done, copy the local memory root to Dropbox:
+
+```bash
+rsync -a --delete ~/.openclaw/memory/ ~/Dropbox/"Knowledge Base - Hex"/
+```
+
+Expected outcomes:
+- Dropbox receives a backup copy of the local memory root
+- agents continue reading and writing locally in `~/.openclaw/memory`
+- no symlink dependency exists in the runtime path
+
+## Existing Data Policy
+
+Do not perform a destructive migration of legacy memory files.
+
+Preserve these as historical context:
+- `memory/YYYY-MM-DD.md`
+- `memory/people/`
+- `memory/projects/`
+- `memory/topics/`
+- `memory/decisions/`
+- `memory/learning/`
+
+Going forward:
+- new compiled knowledge belongs in Cortex
+- `MEMORY.md` should become a routing layer, not the primary long-form store
+- legacy librarian-style curation should phase out
+
+## Writer and Reader Roles
+
+Even without locking, operate Cortex as a single-writer system.
+
+- **Writer machine**: allowed to run ingest, lint, rebuild-index, and structural updates
+- **Reader machine**: reads linked knowledge, avoids structural writes
+
+This prevents churn and accidental divergence.
+
+## Verification Checklist
+
+After rollout, verify all of the following:
+
+- [ ] `~/.config/cortex/config` exists
+- [ ] primary store exists directly in `~/.openclaw/memory/`
+- [ ] Dropbox backup target exists
+- [ ] `.cortex.db` exists
+- [ ] `schema.md` exists
+- [ ] `cortex status` succeeds against the local memory root
+- [ ] no runtime dependency on symlinked memory paths remains
+- [ ] backup command copies local state to Dropbox successfully
+- [ ] agent-facing docs describe the memory root as the source of truth
+
+## Known Risks
+
+### Split-brain memory
+Operators may continue treating `memory/` as the primary long-term knowledge store.
+
+Mitigation:
+- document Cortex as the new source of truth for compiled knowledge
+- keep `MEMORY.md` thin and pointer-oriented
+
+### Namespace collisions
+Multiple assistants sharing `Knowledge Base` causes confusion and ownership ambiguity.
+
+Mitigation:
+- use assistant-specific names like `Knowledge Base - Hex`
+
+### Symlinked runtime storage
+Using a symlinked runtime memory store proved unreliable in practice.
+
+Mitigation:
+- keep runtime state local under `~/.openclaw/memory`
+- use Dropbox as backup only
+
+### Doc drift
+Older design docs may still describe superseded v1 behavior.
+
+Mitigation:
+- treat `skills/cortex/SKILL.md` and the CLI behavior as the operational source of truth
+- update migration docs whenever rollout practice changes
+
+## Verified Hex Notes
+
+On Hex, rollout guidance was corrected after testing:
+- symlinking the runtime memory store to Dropbox was not the right model
+- the correct pattern is local primary storage under `~/.openclaw/memory`, with Dropbox backup every 3 hours
+
+Hex now uses:
+- local primary store: `~/.openclaw/memory/`
+- Dropbox backup target: `~/Dropbox/Knowledge Base - Hex/`
+
+This is the recommended pattern for future multi-assistant rollouts unless a stronger storage model is introduced.

--- a/skills/cortex/SKILL.md
+++ b/skills/cortex/SKILL.md
@@ -33,7 +33,8 @@ cortex: diverse inputs come in, coherent understanding comes out.
 
 ## What Cortex Is
 
-A knowledge compiler and memory system stored as plain markdown in local OpenClaw memory, with optional Dropbox backup:
+A knowledge compiler and memory system stored as plain markdown in local OpenClaw
+memory, with optional Dropbox backup:
 
 - **Sources** — Documents, notes, transcripts, captures anywhere on disk. You read but
   never modify them.
@@ -42,7 +43,8 @@ A knowledge compiler and memory system stored as plain markdown in local OpenCla
 - **Schema** (`schema.md`) — Your operating rules. Read it before every ingest or lint.
 - **MEMORY.md** — A ~30-line routing table at `~/.openclaw/memory/MEMORY.md`, always
   loaded into agent context.
-- **Backup** — Copy the local knowledge base to Dropbox periodically, for example every 3 hours.
+- **Backup** — Copy the local knowledge base to Dropbox periodically, for example every
+  3 hours.
 
 ## Store Layout
 
@@ -50,7 +52,7 @@ A knowledge compiler and memory system stored as plain markdown in local OpenCla
 ~/.openclaw/memory/                  <- Cortex primary store root
   schema.md                            <- LLM instruction set
   index.md                             <- Root navigation hub
-  .cortex.db                           <- SQLite state (gitignored)
+  cortex.db                            <- SQLite state (gitignored)
   .log                                 <- Operation log
   review-queue.md                      <- Items needing human review
   entities/                            <- People, companies, tools, projects
@@ -67,12 +69,13 @@ A knowledge compiler and memory system stored as plain markdown in local OpenCla
 
 Stored directly in `~/.openclaw/memory/`, with no Cortex subfolder.
 
-If off-machine backup is desired, copy the memory root to `~/Dropbox/Knowledge Base - <agentname>/` on a schedule instead of using a symlink.
+If off-machine backup is desired, copy the memory root to
+`~/Dropbox/Knowledge Base - <agentname>/` on a schedule instead of using a symlink.
 
 ## How Agents Access Cortex
 
-Navigate: `<link-name>/index.md` -> category `index.md` -> specific pages. Two hops,
-bounded context.
+Navigate: `~/.openclaw/memory/index.md` -> category `index.md` -> specific pages. Two
+hops, bounded context.
 
 ## Operations
 
@@ -169,7 +172,8 @@ For processing large numbers of files:
    captures
 6. After all batches, run a full lint to stitch cross-references
 7. Review `review-queue.md` for items needing human attention
-8. Set up backup copy to Dropbox after initial ingest, for example with a 3-hour sync job
+8. Set up backup copy to Dropbox after initial ingest, for example with a 3-hour sync
+   job
 
 ### Resumption
 

--- a/skills/cortex/SKILL.md
+++ b/skills/cortex/SKILL.md
@@ -33,20 +33,21 @@ cortex: diverse inputs come in, coherent understanding comes out.
 
 ## What Cortex Is
 
-A knowledge compiler and memory system stored as plain markdown in cloud storage:
+A knowledge compiler and memory system stored as plain markdown in local OpenClaw memory, with optional Dropbox backup:
 
 - **Sources** — Documents, notes, transcripts, captures anywhere on disk. You read but
   never modify them.
 - **Knowledge Base** — You own this. Structured, interlinked pages with YAML frontmatter
-  in `~/Dropbox/Knowledge Base/`.
+  directly under `~/.openclaw/memory/`.
 - **Schema** (`schema.md`) — Your operating rules. Read it before every ingest or lint.
 - **MEMORY.md** — A ~30-line routing table at `~/.openclaw/memory/MEMORY.md`, always
   loaded into agent context.
+- **Backup** — Copy the local knowledge base to Dropbox periodically, for example every 3 hours.
 
 ## Store Layout
 
 ```
-~/Dropbox/Knowledge Base/              <- Cortex store (Dropbox-synced)
+~/.openclaw/memory/                  <- Cortex primary store root
   schema.md                            <- LLM instruction set
   index.md                             <- Root navigation hub
   .cortex.db                           <- SQLite state (gitignored)
@@ -61,15 +62,16 @@ A knowledge compiler and memory system stored as plain markdown in cloud storage
   learning/                            <- Self-improvement loop
     archive/                           <- Archived corrections
   daily/                               <- Conversation journals
+  MEMORY.md                            <- Routing table / quick links
 ```
 
-Accessed via symlink after ingest: `~/.openclaw/memory/Knowledge Base/` (Run
-`cortex link` after bulk ingest is complete — linking during ingest causes re-index
-churn.)
+Stored directly in `~/.openclaw/memory/`, with no Cortex subfolder.
+
+If off-machine backup is desired, copy the memory root to `~/Dropbox/Knowledge Base - <agentname>/` on a schedule instead of using a symlink.
 
 ## How Agents Access Cortex
 
-Navigate: `Knowledge Base/index.md` -> category `index.md` -> specific pages. Two hops,
+Navigate: `<link-name>/index.md` -> category `index.md` -> specific pages. Two hops,
 bounded context.
 
 ## Operations
@@ -94,7 +96,7 @@ For bulk ingest, run `cortex scan <dir>` then `cortex plan` to see prioritized b
 
 When answering a question from compiled knowledge:
 
-1. Read `Knowledge Base/index.md` to identify relevant categories
+1. Read `~/.openclaw/memory/index.md` to identify relevant categories
 2. Read the relevant category `index.md`
 3. Read matched pages (cap at 10 per query)
 4. Synthesize answer with citations to sources
@@ -149,7 +151,7 @@ cortex scan <dir>                     # Discover files, classify, hash, store in
 cortex triage                         # Pre-filter low-value files
 cortex plan                           # Show files grouped by directory, sorted oldest-first
 cortex rebuild-index                  # Regenerate indexes from page frontmatter
-cortex link                           # Symlink store into OpenClaw memory (AFTER ingest)
+cortex link                           # Deprecated in this rollout pattern, prefer local store plus backup copy
 ```
 
 For document extraction (PDF, DOCX, PPTX, etc.), use docling directly:
@@ -167,7 +169,7 @@ For processing large numbers of files:
    captures
 6. After all batches, run a full lint to stitch cross-references
 7. Review `review-queue.md` for items needing human attention
-8. `cortex link` — symlink store into OpenClaw memory (triggers re-index, so do last)
+8. Set up backup copy to Dropbox after initial ingest, for example with a 3-hour sync job
 
 ### Resumption
 
@@ -192,3 +194,5 @@ index. The operator decides which model to use based on the source quality and c
 - Entity pages for people are living documents — update to current state with inline
   history for changed facts
 - This skill replaces the librarian — all memory maintenance is now handled by Cortex
+- Treat `~/.openclaw/memory` as the source of truth, not Dropbox
+- Back up the memory root to `~/Dropbox/Knowledge Base - <agentname>/`

--- a/skills/cortex/cortex
+++ b/skills/cortex/cortex
@@ -107,7 +107,7 @@ def get_store_path() -> Path:
 
 def get_db_path() -> Path:
     """Get the SQLite database path."""
-    return get_store_path() / ".cortex.db"
+    return get_store_path() / "cortex.db"
 
 
 def get_db() -> sqlite3.Connection:
@@ -322,11 +322,11 @@ def cmd_setup() -> None:
     # Create .gitignore
     gitignore = store_path / ".gitignore"
     if not gitignore.exists():
-        gitignore.write_text(".obsidian/\n.cortex.db\n.cortex.db-wal\n.cortex.db-shm\n*.log\n")
+        gitignore.write_text(".obsidian/\ncortex.db\ncortex.db-wal\ncortex.db-shm\n*.log\n")
         print("Created .gitignore")
 
     # Initialize SQLite
-    db_path = store_path / ".cortex.db"
+    db_path = store_path / "cortex.db"
     if not db_path.exists():
         init_db(db_path)
         print("Initialized SQLite database")

--- a/skills/cortex/schema-template.md
+++ b/skills/cortex/schema-template.md
@@ -9,7 +9,7 @@ set. Read it before every ingest or lint operation.
 ### Store Layout
 
 ```
-~/Dropbox/Knowledge Base/              <- Cortex store (Dropbox-synced)
+~/.openclaw/memory/                  <- Cortex primary store root
   schema.md                            <- This file. Your operating rules.
   index.md                             <- Root navigation hub
   .cortex.db                           <- SQLite state (gitignored)
@@ -42,13 +42,15 @@ absolute path to each original source. Sources are immutable — you never modif
 
 ### Access via OpenClaw
 
-The store is symlinked into the OpenClaw memory path:
+The knowledge base lives directly in the OpenClaw memory root.
+
+Back it up separately to a Dropbox path such as:
 
 ```
-~/.openclaw/memory/Knowledge Base/ -> ~/Dropbox/Knowledge Base/
+~/Dropbox/Knowledge Base - Hex/
 ```
 
-Agents navigate: `Knowledge Base/index.md` -> category `index.md` -> specific pages. Two
+Agents navigate: `index.md` -> category `index.md` -> specific pages. Two
 hops, bounded context.
 
 ## Page Types
@@ -601,9 +603,9 @@ agents. This is always loaded into conversation context.
 
 ## Quick Links
 
-- [Recent Decisions](Knowledge Base/decisions/)
-- [All Entities](Knowledge Base/entities/index.md)
-- [Knowledge Base Index](Knowledge Base/index.md)
+- [Recent Decisions](decisions/)
+- [All Entities](entities/index.md)
+- [Knowledge Base Index](index.md)
 ```
 
 ### Daily Journal Files

--- a/skills/cortex/schema-template.md
+++ b/skills/cortex/schema-template.md
@@ -12,7 +12,7 @@ set. Read it before every ingest or lint operation.
 ~/.openclaw/memory/                  <- Cortex primary store root
   schema.md                            <- This file. Your operating rules.
   index.md                             <- Root navigation hub
-  .cortex.db                           <- SQLite state (gitignored)
+  cortex.db                            <- SQLite state (gitignored)
   .log                                 <- Operation log (not .md to avoid indexing)
   review-queue.md                      <- Items needing human review
   .gitignore
@@ -47,11 +47,11 @@ The knowledge base lives directly in the OpenClaw memory root.
 Back it up separately to a Dropbox path such as:
 
 ```
-~/Dropbox/Knowledge Base - Hex/
+~/Dropbox/Knowledge Base - <agentname>/
 ```
 
-Agents navigate: `index.md` -> category `index.md` -> specific pages. Two
-hops, bounded context.
+Agents navigate: `index.md` -> category `index.md` -> specific pages. Two hops, bounded
+context.
 
 ## Page Types
 

--- a/tests/test_cortex.py
+++ b/tests/test_cortex.py
@@ -98,7 +98,7 @@ def cortex_store(tmp_path):
     (store / "review-queue.md").write_text("# Review Queue\n\n_No items pending._\n")
 
     # Initialize SQLite
-    _init_store_db(store / ".cortex.db")
+    _init_store_db(store / "cortex.db")
 
     # Config at fake_home/.config/cortex/config
     fake_home = tmp_path / "home"
@@ -243,7 +243,7 @@ class TestScan:
     ):
         """Re-scan updates hash for files previously recorded as online-only."""
         store, _ = cortex_store
-        db_path = store / ".cortex.db"
+        db_path = store / "cortex.db"
 
         source_dir = tmp_path / "sources"
         source_dir.mkdir()


### PR DESCRIPTION
## Summary
- document Cortex rollout using ~/.openclaw/memory as the primary store
- document Dropbox backup to ~/Dropbox/Knowledge Base - <agentname>
- add a migration guide for librarian -> cortex rollout
- update Cortex docs and schema examples to match the corrected architecture

## Verification
- uv run --with pytest pytest tests/test_cortex.py -q
- verified Hex rollout locally with memory root storage and rsync backup