### PR TITLE
Remove dead help entry from quo COMMAND_MAP

### DIFF
--- a/skills/quo/quo
+++ b/skills/quo/quo
@@ -1113,7 +1113,6 @@ COMMAND_MAP = {
     "messages": cmd_messages,
     "calls": cmd_calls,
     "raw": cmd_raw,
-    "help": lambda args: cmd_help(),
 }
 
 


### PR DESCRIPTION
## Summary

Addresses Cursor bot feedback from PR #92:
- Removed unreachable "help" entry from COMMAND_MAP in skills/quo/quo

## Details

The help check on line 1125 intercepts "help" before COMMAND_MAP lookup, making the "help": lambda entry unreachable dead code.

**Note**: Cursor also flagged a YAML syntax issue in skills/quo/SKILL.md, but validation shows the YAML is correct - that appears to be incorrect analysis.

## Test plan

- [x] Validated YAML syntax with Python's yaml.safe_load
- [x] Confirmed help command still works (handled by early check on line 1125)
- [x] Confirmed other commands route through COMMAND_MAP correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)