### PR TITLE
fix(health-check): replace unmeasurable 5-min D/U threshold with observable signal

### DIFF
--- a/devops/health-check.md
+++ b/devops/health-check.md
@@ -177,8 +177,10 @@ This catches stale chat IDs, users who haven't /started the bot, and misconfigur
 targets before they cause delivery failures.
 
 **Hung processes.** Look for truly stuck OpenClaw-owned processes. The reliable hang
-signal (not just idleness) is uninterruptible wait held >5 minutes — `U` on macOS (per
-`ps -o state`), `D` on Linux.
+signal (not just idleness) is kernel-reported uninterruptible wait — `U` on macOS, `D`
+on Linux (per `ps -o state`). Note: `ps` reports current state only, not duration. Treat
+any observed `U`/`D` on an OpenClaw-owned process as a flag worth investigating —
+compare against the previous health check's findings if available to gauge persistence.
 
 Do **not** use as hang signals: log-file mtime, "quiet log," or 0% CPU alone. Many
 OpenClaw-adjacent processes sleep on sockets or idle between work bursts — all read 0%


### PR DESCRIPTION
## Summary

- `ps -o state` reports current kernel state only, not how long a process has been in that state
- The "held >5 minutes" qualifier on D/U hang detection was unimplementable without cross-run state tracking
- Replace with: treat any observed `U`/`D` as a flag worth investigating, comparing to previous check findings for persistence

Addresses Cursor Bugbot feedback on PR #100 (comment ID 3115208323).

## Test plan

- [ ] Health check cron picks up the updated instruction on next fleet deploy
- [ ] Verify hung-process detection guidance is implementable by the LLM agent without external state tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)