### PR TITLE
fix(bridge-health): address review-sweep findings from PR #96

### DIFF
--- a/workflows/bridge-health/AGENT.md
+++ b/workflows/bridge-health/AGENT.md
@@ -366,9 +366,10 @@ Run these, as applicable:
 - `wacli chats list --limit 1 --json` (parse latest-message timestamp from the returned
   chat; compare to the host's freshness window from `## Configured Bridges`)
 - `pgrep -fal "wacli sync --follow"` (only if sync-follow is expected on this host)
-- windowed error-event count: tail the last 5 minutes of `~/.wacli/sync.log` (and
-  `sync-error.log` if present) and count lines containing any of `websocket`,
-  `reconnect`, `401`, `store locked`, `timeout`, `Client outdated`
+- windowed error-event count: select the live log by mtime — `sync-error.log` is
+  typically the running log; `sync.log` is often stale from a previous run — then
+  `tail -n 200` it and count lines from the last 5 minutes containing any of
+  `websocket`, `reconnect`, `401`, `store locked`, `timeout`, `Client outdated`
 
 Interpretation order:
 
@@ -399,7 +400,9 @@ Do **not** restart `wacli` from a single-run signal or from log silence.
 Run these, as applicable:
 
 - `tgcli --version`
-- `tgcli chat ls --limit 1 --json`
+- `tgcli chat ls --limit 5 --json` (fetch several chats — sort order is not
+  recency-first, so take the max `last_message_ts` across results, ignoring zero-value
+  sentinels)
 - optionally inspect `~/.tgcli/tgcli.db` mtime for cache staleness context
 
 #### imsg
@@ -478,16 +481,17 @@ match; this keeps fingerprints deterministic across runs so dedup actually works
 
 ### wacli precedence
 
-| #   | Signature                     | Condition                                                                         | Severity |
-| --- | ----------------------------- | --------------------------------------------------------------------------------- | -------- |
-| 1   | `wacli-outdated-405`          | `Client outdated (405)` appears in last 5 minutes of the live log                 | P1       |
-| 2   | `wacli-auth-lost`             | `AUTHENTICATED false` from doctor                                                 | P1       |
-| 3   | `wacli-composite-hang`        | live read fails ≥ 2 of 3 attempts AND `CONNECTED false` AND `LastMessageTS` stale | P1       |
-| 4   | `wacli-read-fail`             | live read fails ≥ 2 of 3 attempts (auth intact, not outdated)                     | P1       |
-| 5   | `wacli-stuck-sync`            | live read succeeds but `LastMessageTS` is older than the freshness window         | P2       |
-| 6   | `wacli-sync-missing`          | sync-follow process is absent on a host that expects it, reads still succeed      | P2       |
-| 7   | `wacli-disconnected-degraded` | `CONNECTED false`, reads succeed, windowed error-count = 0                        | P2       |
-| 8   | `wacli-reconnect-churn`       | windowed error-count ≥ 1, reads succeed, `CONNECTED true`                         | P2       |
+| #   | Signature                        | Condition                                                                         | Severity |
+| --- | -------------------------------- | --------------------------------------------------------------------------------- | -------- |
+| 1   | `wacli-outdated-405`             | `Client outdated (405)` appears in last 5 minutes of the live log                 | P1       |
+| 2   | `wacli-auth-lost`                | `AUTHENTICATED false` from doctor                                                 | P1       |
+| 3   | `wacli-composite-hang`           | live read fails ≥ 2 of 3 attempts AND `CONNECTED false` AND `LastMessageTS` stale | P1       |
+| 4   | `wacli-read-fail`                | live read fails ≥ 2 of 3 attempts (auth intact, not outdated)                     | P1       |
+| 5   | `wacli-stuck-sync`               | live read succeeds but `LastMessageTS` is older than the freshness window         | P2       |
+| 6   | `wacli-sync-missing`             | sync-follow process is absent on a host that expects it, reads still succeed      | P2       |
+| 7   | `wacli-disconnected-degraded`    | `CONNECTED false`, reads succeed, windowed error-count = 0                        | P2       |
+| 8   | `wacli-reconnect-churn`          | windowed error-count ≥ 1, reads succeed, `CONNECTED true`                         | P2       |
+| 9   | `wacli-disconnected-with-errors` | `CONNECTED false`, reads succeed, windowed error-count ≥ 1                        | P2       |
 
 ### tgcli precedence
 
@@ -495,7 +499,8 @@ match; this keeps fingerprints deterministic across runs so dedup actually works
 | --- | ------------------------ | ------------------------------------------------------------------- | -------- |
 | 1   | `tgcli-store-unreadable` | store file missing or I/O error on access                           | P1       |
 | 2   | `tgcli-not-logged-in`    | auth check fails or `tgcli chat ls` returns unauthenticated error   | P1       |
-| 3   | `tgcli-stale-cache`      | reads succeed but latest-message timestamp outside freshness window | P2       |
+| 3   | `tgcli-read-fail`        | live read fails ≥ 2 of 3 attempts (auth intact, store accessible)   | P1       |
+| 4   | `tgcli-stale-cache`      | reads succeed but latest-message timestamp outside freshness window | P2       |
 
 ### imsg precedence
 

--- a/workflows/bridge-health/agent_notes.md
+++ b/workflows/bridge-health/agent_notes.md
@@ -2,11 +2,11 @@
 
 ## Patterns Observed
 
-- 2026-04-19: On Cora (Nick's Mac Studio), `wacli doctor` returned
-  `AUTHENTICATED true` + `CONNECTED false` while live reads succeeded with a fresh
-  `LastMessageTS` (~8 min old). The old model would have flagged this as Down; the
-  active-probe model correctly classifies it as Degraded-P2 (monitor only). Do not
-  restart on `CONNECTED false` alone when the data plane is serving fresh messages.
+- 2026-04-19: On machine-1, `wacli doctor` returned `AUTHENTICATED true` +
+  `CONNECTED false` while live reads succeeded with a fresh `LastMessageTS` (~8 min
+  old). The old model would have flagged this as Down; the active-probe model correctly
+  classifies it as Degraded-P2 (monitor only). Do not restart on `CONNECTED false` alone
+  when the data plane is serving fresh messages.
 - 2026-04-19: wacli JSON response shape on this host: `.data[0].LastMessageTS` (ISO-8601
   UTC, e.g. `2026-04-20T02:53:58Z`). Use that field for forward-progress checks.
 - 2026-04-19: wacli live log is `~/.wacli/sync-error.log` (despite the name), not


### PR DESCRIPTION
## Summary

Follow-up to #96 (Rewrite bridge-health workflow around active probes) addressing all bot review findings.

- **Remove PII from agent_notes.md** — replaced `Cora (Nick's Mac Studio)` with `machine-1` per zero-PII/zero-fleet-specifics policy; caught by both Codex (P1) and Cursor
- **Fix wacli log contradiction** — Required Checks now selects the live log by mtime (matching the health model), instead of tailing both `sync.log` and `sync-error.log` which could inflate error counts from stale logs
- **Fix tgcli limit contradiction** — Required Checks now uses `--limit 5` with max-timestamp logic, aligning with the health model's "fetch several chats, not just 1" guidance (chat[0] can have a zero-value sentinel)
- **Add wacli signature #9 (`wacli-disconnected-with-errors`)** — closes coverage gap where `CONNECTED false` + reads succeed + error-count ≥ 1 matched neither #7 (requires error-count = 0) nor #8 (requires CONNECTED true)
- **Add tgcli signature #3 (`tgcli-read-fail`)** — Down-severity read failures from timeouts/crashes/network errors had no fingerprint; only auth failures and store I/O were covered

## Test plan

- [ ] Deploy updated workflow to a fleet host and run bridge-health in healthcheck mode
- [ ] Confirm tgcli check fetches 5 chats and correctly takes max timestamp
- [ ] Confirm wacli log tailing selects by mtime, not hardcoded filename
- [ ] Confirm new wacli/tgcli signatures appear in `## Active Incidents` when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)