### PR TITLE
fix(apple-photos): fix --edited filter and un-toggleable export flags

### DIFF
--- a/skills/apple-photos/SKILL.md
+++ b/skills/apple-photos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-photos
-version: 0.1.0
+version: 0.1.1
 description:
   Query, inspect, and export photos from the macOS Apple Photos library using osxphotos.
   Find photos by person, album, keyword, or date range. Export candidates for curation

--- a/skills/apple-photos/apple-photos
+++ b/skills/apple-photos/apple-photos
@@ -107,8 +107,12 @@ def cmd_people(args: argparse.Namespace) -> None:
 # -- Shared query builder -----------------------------------------------------
 
 
-def build_query_options(args: argparse.Namespace) -> QueryOptions:
-    """Build QueryOptions from parsed CLI arguments."""
+def build_query_options(args: argparse.Namespace, *, edited_filter: bool = True) -> QueryOptions:
+    """Build QueryOptions from parsed CLI arguments.
+
+    edited_filter controls whether --edited narrows the query to only edited photos.
+    Pass False for export, where --edited means "prefer edited source" not "only edited".
+    """
     return QueryOptions(
         person=args.person or None,
         album=args.album or None,
@@ -116,7 +120,7 @@ def build_query_options(args: argparse.Namespace) -> QueryOptions:
         from_date=parse_date(args.after),
         to_date=parse_date(args.before),
         favorite=True if getattr(args, "favorite", False) else None,
-        edited=True if getattr(args, "edited", False) else None,
+        edited=True if (edited_filter and getattr(args, "edited", False)) else None,
         photos=True,
         movies=getattr(args, "movies", False),
         newest_first=getattr(args, "newest_first", False),
@@ -149,7 +153,8 @@ def cmd_query(args: argparse.Namespace) -> None:
 def cmd_export(args: argparse.Namespace) -> None:
     """Export matched photos to a destination directory."""
     db = get_db(args.library)
-    photos = db.query(build_query_options(args))
+    # edited_filter=False: --edited means "prefer edited source", not "only edited photos"
+    photos = db.query(build_query_options(args, edited_filter=False))
     if args.limit:
         photos = photos[: args.limit]
 
@@ -228,8 +233,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_export.add_argument("--after", help="Photos on/after this date (YYYY-MM-DD)")
     p_export.add_argument("--before", help="Photos before this date (YYYY-MM-DD)")
     p_export.add_argument("--edited", action="store_true", help="Prefer edited versions")
-    p_export.add_argument("--movies", action="store_true", default=True, help="Include movies (default: on)")
-    p_export.add_argument("--newest-first", action="store_true", default=True, help="Sort newest first (default: on)")
+    p_export.add_argument("--movies", action=argparse.BooleanOptionalAction, default=True, help="Include movies (default: on, --no-movies to exclude)")
+    p_export.add_argument("--newest-first", action=argparse.BooleanOptionalAction, default=True, help="Sort newest first (default: on, --no-newest-first to disable)")
     p_export.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
     p_export.add_argument("--dry-run", action="store_true")
 


### PR DESCRIPTION
## Summary

Follow-up fixes for bugs caught by Cursor Bugbot on PR #91 (`feat: add apple-photos skill`).

- **`--edited` silently excludes non-edited photos from export**: `build_query_options` was passing `edited=True` to `QueryOptions`, which pre-filtered the query to only photos with edits — meaning `cmd_export`'s "prefer edited source" logic on line 162 never saw non-edited photos at all. Fixed by adding `edited_filter=False` for the export path so the filter doesn't apply, letting source selection handle the preference correctly.

- **`--movies` and `--newest-first` are permanent no-ops on export**: `action="store_true"` combined with `default=True` means these flags are always `True` with no way to opt out. Switched to `argparse.BooleanOptionalAction`, which adds `--no-movies` / `--no-newest-first` and gives users the "default on, opt-out possible" behavior the help text implied.

## Test plan

- [ ] All 35 unit tests pass (`uv run --with pytest pytest tests/test_apple_photos.py -v`)
- [ ] `apple-photos export /tmp/out --no-movies` now correctly excludes movies
- [ ] `apple-photos export /tmp/out --edited` now includes non-edited photos (using their originals), not silently filtering them out
- [ ] `apple-photos export /tmp/out --edited` still copies edited versions where available

Closes: review feedback on #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)