### PR TITLE
fix(apple-photos): review-sweep fixes from PR #91 bot analysis

### DIFF
--- a/skills/apple-photos/SKILL.md
+++ b/skills/apple-photos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-photos
-version: 0.1.0
+version: 0.1.1
 description:
   Query, inspect, and export photos from the macOS Apple Photos library using osxphotos.
   Find photos by person, album, keyword, or date range. Export candidates for curation

--- a/skills/apple-photos/apple-photos
+++ b/skills/apple-photos/apple-photos
@@ -107,8 +107,14 @@ def cmd_people(args: argparse.Namespace) -> None:
 # -- Shared query builder -----------------------------------------------------
 
 
-def build_query_options(args: argparse.Namespace) -> QueryOptions:
-    """Build QueryOptions from parsed CLI arguments."""
+def build_query_options(args: argparse.Namespace, *, skip_edited_filter: bool = False) -> QueryOptions:
+    """Build QueryOptions from parsed CLI arguments.
+
+    skip_edited_filter: when True, don't filter to only-edited photos at the DB level.
+    Use this for export, where --edited means "prefer edited source" (handled in cmd_export),
+    not "exclude non-edited photos."
+    """
+    edited = None if skip_edited_filter else (True if getattr(args, "edited", False) else None)
     return QueryOptions(
         person=args.person or None,
         album=args.album or None,
@@ -116,7 +122,7 @@ def build_query_options(args: argparse.Namespace) -> QueryOptions:
         from_date=parse_date(args.after),
         to_date=parse_date(args.before),
         favorite=True if getattr(args, "favorite", False) else None,
-        edited=True if getattr(args, "edited", False) else None,
+        edited=edited,
         photos=True,
         movies=getattr(args, "movies", False),
         newest_first=getattr(args, "newest_first", False),
@@ -149,7 +155,8 @@ def cmd_query(args: argparse.Namespace) -> None:
 def cmd_export(args: argparse.Namespace) -> None:
     """Export matched photos to a destination directory."""
     db = get_db(args.library)
-    photos = db.query(build_query_options(args))
+    # skip_edited_filter: --edited controls source selection (prefer edited path), not DB filtering
+    photos = db.query(build_query_options(args, skip_edited_filter=True))
     if args.limit:
         photos = photos[: args.limit]
 
@@ -228,8 +235,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_export.add_argument("--after", help="Photos on/after this date (YYYY-MM-DD)")
     p_export.add_argument("--before", help="Photos before this date (YYYY-MM-DD)")
     p_export.add_argument("--edited", action="store_true", help="Prefer edited versions")
-    p_export.add_argument("--movies", action="store_true", default=True, help="Include movies (default: on)")
-    p_export.add_argument("--newest-first", action="store_true", default=True, help="Sort newest first (default: on)")
+    p_export.add_argument("--movies", action=argparse.BooleanOptionalAction, default=True, help="Include movies (default: on, use --no-movies to exclude)")
+    p_export.add_argument("--newest-first", action=argparse.BooleanOptionalAction, default=True, help="Sort newest first (default: on, use --no-newest-first to disable)")
     p_export.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
     p_export.add_argument("--dry-run", action="store_true")
 


### PR DESCRIPTION
## Summary

Follow-up to #91 (`feat: add apple-photos skill`), addressing real bugs caught by Cursor and Codex review bots.

- **`--edited` on export silently excluded non-edited photos** — `QueryOptions(edited=True)` was filtering at the DB level before `cmd_export`'s "prefer edited path" logic ran, so non-edited photos were never seen. Fixed by passing `skip_edited_filter=True` to `build_query_options` from `cmd_export`.
- **`--movies` / `--newest-first` export flags were un-toggleable no-ops** — `action="store_true"` + `default=True` makes the value permanently `True` with no opt-out. Switched to `BooleanOptionalAction` to enable `--no-movies` / `--no-newest-first`.

One Codex suggestion was declined (P2 — "HAS_OSXPHOTOS check is wrong"): the bot misread the code ordering. `find_spec` runs on line 21, before the mock injection on lines 26–28. Replied with explanation and 👎 reaction.

## Test plan

- [ ] `apple-photos export /dest --no-movies` now excludes movies (previously impossible)
- [ ] `apple-photos export /dest --edited` now exports all matching photos, using edited version where available (previously silently dropped non-edited photos)
- [ ] `apple-photos export /dest` unchanged — movies on, newest first, all photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)