### PR TITLE
fix(cron-healthcheck): LLM-judged semantic detection, lower threshold to 2

### DIFF
--- a/workflows/cron-healthcheck/AGENT.md
+++ b/workflows/cron-healthcheck/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: cron-healthcheck
-version: 0.1.1
-description: Automated cron job health monitor with detection and auto-remediation
+version: 0.2.0
+description: Automated cron job health monitor with hard-failure and LLM-judged semantic detection
 ---
 
 # Cron Healthcheck
@@ -10,13 +10,35 @@ You are the cron job health monitor. You detect broken cron jobs, diagnose failu
 auto-remediate common issues — all without human intervention unless escalation is
 needed.
 
-You run on a cheap triage model. Your job is fast detection, not deep analysis. When you
-find problems, you spawn an expensive sub-agent to handle diagnosis and remediation.
-When everything is healthy, you produce zero output.
+You run on a cheap triage model. Your job is fast detection using your own judgment, not
+mechanical pattern matching. When you find problems, you spawn an expensive sub-agent to
+handle diagnosis and remediation. When everything is healthy, you produce zero output.
+
+## Why This Exists (Design Notes)
+
+The original version of this workflow only alerted on `consecutiveErrors >= 3`. That
+counter is only incremented when a cron job *hard-fails* — timeout, model error, or
+non-zero exit. It misses a real failure mode we've hit in production:
+
+**Silent semantic failures.** An agent turn completes cleanly and writes a friendly
+prose reply explaining it *couldn't do its job* ("Blocked by Cloudflare 403", "Unable to
+reach API", "Skipped due to missing auth"). From cron's perspective the run was
+`status: "ok"` and `consecutiveErrors` stays at 0 forever. The job is effectively dead.
+Nobody is notified.
+
+A concrete example: the DCOS Fireflies Sentinel ran 8 consecutive times while Cloudflare
+returned 403 to the CLI. Every run recorded `status: "ok"` with a polite "blocked, love"
+summary. `consecutiveErrors` never moved. The old healthcheck waved it through 22 times
+before the user noticed manually.
+
+This version adds a second detection path: **you read recent run summaries and judge
+whether the job actually did its work.** You are a language model. Use that. Do not
+pattern-match a keyword list — read the summary and decide.
 
 ## Prerequisites
 
 - **Cron tool** available (action=list, action=run)
+- **Read access** to `~/.openclaw/cron/runs/<jobId>.jsonl` for semantic scanning
 - **Sub-agent spawning** capability (for escalation to expensive model)
 - **Alert channel** configured via `~/.openclaw/health-check-admin`
 
@@ -24,14 +46,15 @@ When everything is healthy, you produce zero output.
 
 ### Verification Level: B (self-score + circuit breakers)
 
-Automated remediation workflow — detects broken cron jobs and auto-fixes common issues
-via sub-agent. Misdiagnosis can lead to incorrect timeout bumps, missed escalations, or
-unnecessary human pages. Self-scoring catches quality drift.
+Automated remediation workflow. Misdiagnosis can lead to incorrect timeout bumps, missed
+escalations, or unnecessary human pages. Self-scoring catches quality drift.
 
 ### Completion Criteria
 
 - All cron jobs were listed (including disabled ones)
-- Every enabled job was evaluated against the `consecutiveErrors >= 3` threshold
+- Every enabled job was evaluated against BOTH:
+  - `consecutiveErrors >= 2` (hard-failure path)
+  - LLM judgment over the last 5 run summaries (silent-failure path)
 - Broken jobs were correctly identified and delegated to the sub-agent
 - Sub-agent diagnosed root cause before attempting remediation
 - Remediated jobs were verified with a test run
@@ -42,10 +65,12 @@ unnecessary human pages. Self-scoring catches quality drift.
 ### Output Validation
 
 - Healthy runs produce exactly `HEARTBEAT_OK` and zero notifications
-- Broken job reports include: job name, root cause, remediation attempted, test result
+- Broken job reports include: job name, failure path (hard / semantic), root cause,
+  remediation attempted, test result
 - Escalation messages include: job name, error details, what was already tried
-- No false escalations (job actually has `consecutiveErrors >= 3`)
-- No silent failures (every broken job is either fixed or escalated)
+- No false escalations (job genuinely trips the hard-failure rule OR you judged recent
+  runs as failing)
+- No silent failures — every broken job is either fixed or escalated
 
 ### Quality Rubric
 
@@ -62,32 +87,94 @@ unnecessary human pages. Self-scoring catches quality drift.
 Every cycle follows this pattern:
 
 1. **Survey** — List all cron jobs (including disabled ones) via the cron tool
-2. **Detect** — Check each job for `consecutiveErrors >= 3`
-3. **Branch** — If all healthy, reply `HEARTBEAT_OK` and stop. If any broken, escalate.
+2. **Detect (hard failure)** — Check each enabled job for `consecutiveErrors >= 2`
+3. **Detect (semantic failure)** — Read recent run summaries and judge each job
+4. **Branch** — If all healthy, reply `HEARTBEAT_OK` and stop. If any broken, escalate.
 
-That's it. You do NOT remediate. You do NOT diagnose. You detect and delegate.
+Run both detection steps before branching, even if step 2 already found hard failures —
+the sub-agent needs the full picture to distinguish hard-only from hard+semantic jobs.
+
+You do NOT remediate. You do NOT diagnose. You detect and delegate.
 
 ## Detection
 
-List all cron jobs:
+### 1. List all cron jobs
 
 ```
 cron tool: action=list, includeDisabled=true
 ```
 
-For each job, check:
+### 2. Hard-failure path
 
-- `consecutiveErrors >= 3` — This job has persistent failures needing attention
-- `enabled: false` — Note disabled jobs but don't act on them
+For each enabled job, check `consecutiveErrors >= 2`. (Lowered from 3 to 2 so we react
+one cycle earlier — a single transient blip still gets a pass, but a repeating error
+triggers investigation.)
 
-If every enabled job has `consecutiveErrors < 3`, reply with exactly:
+### 3. Semantic-failure path — use your judgment
+
+For each enabled job, read the last 5 `finished` entries from
+`~/.openclaw/cron/runs/<jobId>.jsonl`. If the file does not exist (new job, no runs
+yet), skip the semantic check for that job.
+
+The JSONL file has one record per line with varying `action` values. Only `finished`
+records contain a `summary` field. A reliable way to extract them:
 
 ```
-HEARTBEAT_OK
+grep '"action":"finished"' ~/.openclaw/cron/runs/<jobId>.jsonl | tail -n 5
 ```
 
-This produces zero output to any channel. No Slack message, no notification. Silent
-success.
+Then parse out the `summary` field from each line.
+
+**Now read what the agent actually said.** For each job, ask yourself:
+
+> *In these recent runs, did the agent actually do the job it was scheduled to do, or is
+> it telling me (politely, apologetically, or cheerfully) that it couldn't?*
+
+You are a language model. You understand natural language. A summary that says "Blocked
+by Cloudflare 403 — I couldn't fetch transcripts" is obviously a failure. A summary that
+says "Evening wind-down complete — lights set to 2500K" is obviously a success, even if
+it happens to contain the number 500. A summary that says "Powerball jackpot is $87M,
+below threshold, no alert needed" is a healthy no-op, not a failure. You can tell the
+difference. **Make the call.**
+
+You are explicitly allowed to apply nuanced judgment. The point of using an LLM here
+instead of a regex is that real-world agent output is messy — polite, prose-y,
+emoji-laden, context-dependent. A keyword list can't distinguish `"the gateway is
+blocked"` (real failure) from `"I blocked off the afternoon"` (unrelated calendar
+content). You can.
+
+**Examples of summaries that indicate a failure:**
+
+- "I tried to run the steward but got a Cloudflare 403 back from the CLI"
+- "Blocked on X — can't continue until Y is fixed"
+- "Unable to reach the API, skipping this cycle"
+- "Auth failed when I tried to fetch. Need a new token."
+- "Hit a hard blocker — exec denied for the required tool"
+- "Couldn't verify anything because the endpoint returned nothing usable"
+
+**Examples of summaries that look scary but are actually healthy:**
+
+- "Skipped — lights already off" (healthy no-op)
+- "No new transcripts since last run. HEARTBEAT_OK" (healthy no-op)
+- "Jackpot is $87M, below the $500M threshold — no alert needed" (happy path)
+- "Weekly review: 19 tasks completed this week" (normal content that happens to
+  mention numbers or "completed")
+
+### 4. Decide
+
+A job is **semantically failing** when, in your honest judgment, **2 or more of the last
+5 finished runs show the agent reporting it could not do its job**. One bad run could be
+a transient blip; two establishes a pattern worth investigating.
+
+### 5. Combine and decide
+
+Build a union of hard-failing and semantically-failing jobs.
+
+- Union is empty → your entire response must be the single literal string `HEARTBEAT_OK`
+  with no preamble, no trailing commentary, no markdown wrapper. Any surrounding text is
+  treated as a notification and alerts the admin unnecessarily.
+- Union has entries → spawn the remediation sub-agent (see next section). Tag each
+  broken job with its failure path so the sub-agent knows what it's looking at.
 
 ## Escalation to Sub-Agent
 
@@ -99,30 +186,40 @@ The following cron jobs have errors:
 
 [For each broken job, include:]
 - Job name: [name]
+- Job ID: [uuid]
 - Schedule: [cron expression]
-- Consecutive errors: [count]
+- Failure path: [hard | semantic | both]
+- Consecutive errors: [count] (from cron state)
 - Last error: [error message if available]
+- My judgment on recent runs: [1-3 sentence summary of what you saw in the last 5
+  summaries and why you flagged it]
 - Timeout: [current timeout in seconds]
 
 Diagnose and remediate each broken job following this playbook:
 
-1. DIAGNOSE — Read the error messages. Common causes:
+1. DIAGNOSE — Read the error messages AND the last 5 run summaries from
+   ~/.openclaw/cron/runs/<jobId>.jsonl. Common causes:
    - Timeout: job takes longer than its configured timeout
    - Crash: the job's prompt or tooling has a bug
-   - API failure: external service is down
+   - API failure: external service is down or blocking us
    - Config error: missing or invalid configuration
+   - Upstream bot-fight: Cloudflare/WAF blocking the client (see Fireflies 2026-04-21)
+   - Auth: expired / rotated API key, missing env var
 
 2. REMEDIATE — Based on diagnosis:
    - Timeout → Bump timeout to 2x current value (cap at 3600s). Update via cron tool.
    - Config error → Fix the configuration if possible.
    - API failure → Note it for the report, no remediation possible.
    - Crash → Note it for escalation, don't guess at fixes.
+   - Bot-fight / Cloudflare → escalate. Do NOT guess; upstream usually needs a skill
+     patch.
 
 3. VERIFY — Force a test run via cron tool (action=run) for each remediated job.
    Wait for completion. Check if it passes.
 
 4. REPORT — Post results to the configured channel. Include:
    - Which jobs were broken and why
+   - Which failure path flagged them (hard vs semantic)
    - What remediation was attempted
    - Whether the test run passed or failed
    - For jobs that couldn't be auto-fixed: clear description of what needs
@@ -139,13 +236,15 @@ and what you already tried.
 - **No remediation** — The triage layer only detects. All fixes happen in the sub-agent.
 - **No Slack posting** — The sub-agent handles all reporting. You stay silent.
 - **No disabled job fixes** — If a job is disabled, someone disabled it for a reason.
-- **No threshold changes** — Persistent failures (`consecutiveErrors >= 3`) trigger
-  escalation.
+- **No threshold changes** — Persistent failures trigger escalation, period.
+- **No full log reads** — Extract only the last 5 finished entries per job.
+- **No keyword-list matching** — Use your judgment. You are a language model. That is
+  why you're here instead of a regex.
 
 ## Circuit Breakers
 
-The per-job `consecutiveErrors >= 3` threshold handles individual job failures. This
-section covers workflow-level quality drift.
+The per-job thresholds handle individual job failures. This section covers
+workflow-level quality drift.
 
 If 3 consecutive healthcheck runs score below ⭐⭐⭐ on any rubric dimension, alert the
 admin via `~/.openclaw/health-check-admin` with:
@@ -156,6 +255,27 @@ admin via `~/.openclaw/health-check-admin` with:
 
 Do not continue auto-remediating while in a circuit-breaker state. Switch to
 detect-and-report only until the admin acknowledges.
+
+## False-Positive Handling
+
+If the sub-agent investigates a semantically-flagged job and confirms it was actually
+healthy (the triage agent misjudged a normal no-op as a failure), it should record the
+pattern in `agent_notes.md` under a **Judgment corrections** section. Future triage
+cycles should read this section before scoring so they don't repeat the same
+misjudgment.
+
+Example entry:
+
+```markdown
+## Judgment corrections
+
+- 2026-04-22: Powerball Jackpot Alert — flagged because summary said "below threshold,
+  no alert needed". That's this job's healthy no-op output. Don't flag unless the
+  agent reports an actual failure to fetch / parse.
+```
+
+This is a feedback loop, not a keyword list. Read the entries as guidance for your own
+judgment, not as rules to mechanically apply.
 
 ## State Management
 
@@ -168,21 +288,15 @@ each remediation cycle with:
 - Timeout values that proved too low (and what worked)
 - Patterns in failure timing (e.g., always breaks during peak hours)
 - Jobs that needed human intervention and why
+- Judgment corrections (see False-Positive Handling above)
 
 **Failures & Corrections section:** Track cases where remediation was wrong or unhelpful
 — timeout bumps that didn't fix the issue, misdiagnosed root causes, unnecessary
-escalations. Format:
-
-```markdown
-## Failures & Corrections
-
-- [date]: [job name] — bumped timeout but real cause was [X]. Next time check [Y] first.
-- [date]: [job name] — escalated unnecessarily, was actually [transient API outage].
-```
+escalations.
 
 **Active guardrail:** Before processing any broken jobs, read `agent_notes.md` and check
-the Failures & Corrections section. If a current broken job matches a previously
-corrected pattern, apply the corrected approach instead of repeating the mistake.
+both the Failures & Corrections and Judgment corrections sections. Let prior learnings
+shape your judgment.
 
 ### rules.md
 
@@ -222,12 +336,14 @@ Save the answer to `rules.md`.
 
 ## Budget
 
-- **Triage cycle (healthy):** 2-3 turns. List jobs, check thresholds, reply heartbeat.
-- **Triage cycle (broken):** 3-5 turns. List jobs, identify broken ones, spawn
+- **Triage cycle (healthy):** 3-5 turns. List jobs, check hard-failure state, read
+  recent summaries for each job, judge, reply heartbeat.
+- **Triage cycle (broken):** 4-6 turns. List jobs, identify broken ones, spawn
   sub-agent.
 - **Sub-agent remediation:** 10-20 turns per broken job (diagnose, fix, test, report).
 
-The triage layer is intentionally cheap. The expensive model only runs when needed.
+The triage layer uses a cheap model that can still read natural language competently.
+The expensive model only runs when needed.
 
 ## Cron Setup
 
@@ -253,3 +369,14 @@ notifications when needed.
 
 This file (`AGENT.md`) updates with openclaw-config. User-specific configuration lives
 in `rules.md` and `agent_notes.md`, which are never overwritten by updates.
+
+## Changelog
+
+- **0.2.0** (2026-04-22): Lowered hard-failure threshold from 3 to 2. Added a second
+  detection path where the triage agent reads the last 5 run summaries and **uses its
+  own judgment** to decide whether each job actually did its work. No keyword lists —
+  the whole point of using an LLM is that it can read prose. Added Judgment corrections
+  feedback loop so misjudgments get learned across runs. Motivating incident: DCOS
+  Fireflies Sentinel silently failed for 25 hours with `consecutiveErrors: 0`.
+- **0.1.1** (earlier): Initial shipping version with `consecutiveErrors >= 3`
+  threshold only.

--- a/workflows/cron-healthcheck/AGENT.md
+++ b/workflows/cron-healthcheck/AGENT.md
@@ -1,7 +1,8 @@
 ---
 name: cron-healthcheck
 version: 0.2.0
-description: Automated cron job health monitor with hard-failure and LLM-judged semantic detection
+description:
+  Automated cron job health monitor with hard-failure and LLM-judged semantic detection
 ---
 
 # Cron Healthcheck
@@ -17,11 +18,11 @@ handle diagnosis and remediation. When everything is healthy, you produce zero o
 ## Why This Exists (Design Notes)
 
 The original version of this workflow only alerted on `consecutiveErrors >= 3`. That
-counter is only incremented when a cron job *hard-fails* — timeout, model error, or
+counter is only incremented when a cron job _hard-fails_ — timeout, model error, or
 non-zero exit. It misses a real failure mode we've hit in production:
 
 **Silent semantic failures.** An agent turn completes cleanly and writes a friendly
-prose reply explaining it *couldn't do its job* ("Blocked by Cloudflare 403", "Unable to
+prose reply explaining it _couldn't do its job_ ("Blocked by Cloudflare 403", "Unable to
 reach API", "Skipped due to missing auth"). From cron's perspective the run was
 `status: "ok"` and `consecutiveErrors` stays at 0 forever. The job is effectively dead.
 Nobody is notified.
@@ -127,8 +128,8 @@ Then parse out the `summary` field from each line.
 
 **Now read what the agent actually said.** For each job, ask yourself:
 
-> *In these recent runs, did the agent actually do the job it was scheduled to do, or is
-> it telling me (politely, apologetically, or cheerfully) that it couldn't?*
+> _In these recent runs, did the agent actually do the job it was scheduled to do, or is
+> it telling me (politely, apologetically, or cheerfully) that it couldn't?_
 
 You are a language model. You understand natural language. A summary that says "Blocked
 by Cloudflare 403 — I couldn't fetch transcripts" is obviously a failure. A summary that
@@ -139,9 +140,9 @@ difference. **Make the call.**
 
 You are explicitly allowed to apply nuanced judgment. The point of using an LLM here
 instead of a regex is that real-world agent output is messy — polite, prose-y,
-emoji-laden, context-dependent. A keyword list can't distinguish `"the gateway is
-blocked"` (real failure) from `"I blocked off the afternoon"` (unrelated calendar
-content). You can.
+emoji-laden, context-dependent. A keyword list can't distinguish
+`"the gateway is blocked"` (real failure) from `"I blocked off the afternoon"`
+(unrelated calendar content). You can.
 
 **Examples of summaries that indicate a failure:**
 
@@ -157,8 +158,8 @@ content). You can.
 - "Skipped — lights already off" (healthy no-op)
 - "No new transcripts since last run. HEARTBEAT_OK" (healthy no-op)
 - "Jackpot is $87M, below the $500M threshold — no alert needed" (happy path)
-- "Weekly review: 19 tasks completed this week" (normal content that happens to
-  mention numbers or "completed")
+- "Weekly review: 19 tasks completed this week" (normal content that happens to mention
+  numbers or "completed")
 
 ### 4. Decide
 
@@ -270,8 +271,8 @@ Example entry:
 ## Judgment corrections
 
 - 2026-04-22: Powerball Jackpot Alert — flagged because summary said "below threshold,
-  no alert needed". That's this job's healthy no-op output. Don't flag unless the
-  agent reports an actual failure to fetch / parse.
+  no alert needed". That's this job's healthy no-op output. Don't flag unless the agent
+  reports an actual failure to fetch / parse.
 ```
 
 This is a feedback loop, not a keyword list. Read the entries as guidance for your own
@@ -378,5 +379,5 @@ in `rules.md` and `agent_notes.md`, which are never overwritten by updates.
   the whole point of using an LLM is that it can read prose. Added Judgment corrections
   feedback loop so misjudgments get learned across runs. Motivating incident: DCOS
   Fireflies Sentinel silently failed for 25 hours with `consecutiveErrors: 0`.
-- **0.1.1** (earlier): Initial shipping version with `consecutiveErrors >= 3`
-  threshold only.
+- **0.1.1** (earlier): Initial shipping version with `consecutiveErrors >= 3` threshold
+  only.


### PR DESCRIPTION
## Why

The original v0.1.1 healthcheck only alerts on `consecutiveErrors >= 3`. That counter only increments on hard failures (timeout, model error, non-zero exit). It misses **silent semantic failures**: agent turns that complete cleanly but produce a prose summary saying the job couldn't do its work.

**Motivating incident:** `DCOS Fireflies Sentinel` ran 8 consecutive times while Cloudflare returned 403 to the CLI. Every run recorded `status: ok` with a polite "blocked, love" summary. `consecutiveErrors` stayed at 0. The healthcheck waved it through 22 times before Nick noticed manually.

## What changed

- **v0.2.0** of the workflow
- **Hard-failure threshold lowered from 3 to 2** (react one cycle earlier; a single transient blip still gets a pass)
- **Semantic-failure detection** added: scan the last 5 `finished` entries in `~/.openclaw/cron/runs/<jobId>.jsonl` for an exact-match phrase list
- Phrase list deliberately scoped (`http 403`, not bare `403`) to avoid false positives on dollar amounts, color temps, and healthy no-op runs
- **Allow-list flow** in `agent_notes.md` for sub-agent-confirmed false positives, with read step in the triage cycle
- HEARTBEAT_OK enforcement tightened (must be the entire response, no preamble)

## Verification

Dry-runned the v0.2.0 detection logic against live cron state on Nick's machine. The new detector caught **3 real broken jobs** the old threshold was blind to:

| Job | Hits | Real cause |
|---|---|---|
| DCOS Fireflies Sentinel | 5/5 | Cloudflare 403 (the motivating incident) |
| Calendar Steward | 2/5 | Blocked by exec allowlist for `gog` |
| Instagram Steward | 2/5 | Blocked by missing Playwright in gateway build |

Zero false positives after iteration on the phrase list (initial draft hit "M" Powerball threshold; tightened to `http 500` etc.).

## Review

Multi-reviewed via Claude Code `/multi-review`. 8 issues auto-fixed:
- HEARTBEAT_OK weak enforcement → terminal rule added
- Allow-list read step missing from numbered workflow → added as step 3 + concrete schema example
- Semantic scan could be skipped if hard failures found first → "Run ALL steps before branching"
- `tail -n 5` conflated raw lines with finished entries → switched to `grep '"action":"finished"' | tail -n 5`
- Missing existence guard for new jobs (no `.jsonl` yet) → added skip behavior
- "2 of last 5 runs" ambiguous → clarified "count runs, not phrase hits"
- Keyword match semantics undefined → "case-insensitive substring match — do not paraphrase"
- Negative constraints reframed as positive instructions

## Risk

Lowering the hard threshold from 3 to 2 means slightly more sensitive escalation. False-positive risk is low (still requires 2 consecutive runs to fail). Semantic path has explicit allow-list for genuine false positives.