### PR TITLE
feat(budget-guard): per-cron monthly spend caps from Paperclip Cost Control

### DIFF
--- a/docs/budget-guard.md
+++ b/docs/budget-guard.md
@@ -1,0 +1,60 @@
+# Budget Guard
+
+Per-cron and per-agent monthly LLM spend caps with automatic disable on breach.
+
+## What it does
+
+Once a day at 11:55 CT, `budget-guard` reads month-to-date spend and compares
+each cron / agent label against caps declared in `workflows/budget-guard/rules.md`.
+
+| State | Threshold | Action |
+| --- | --- | --- |
+| `ok` | < 80 % of cap | nothing |
+| `warn` | 80 – 99 % | one-time daily warning to `📋 Automation` |
+| `breach` | ≥ 100 % | disable the cron, log it, post to `📋 Automation` |
+
+Essential crons (listed in `rules.md#essential_crons`) max out at `warn`.
+They never auto-disable.
+
+## Why we built it
+
+`llm-usage-report` shows yesterday's spend at noon. By the time you see the
+report, a runaway cron has already burned 24h of budget. Budget guard catches
+the runaway in-flight and stops it.
+
+The pattern is borrowed from `paperclipai/paperclip`'s "Cost Control" primitive.
+Paperclip enforces budgets at the agent level inside their control plane. We
+enforce at the cron level because that matches the OpenClaw fleet's actual unit
+of deployment.
+
+## Setup
+
+```bash
+openclaw cron add --name "budget-guard-daily" \
+  --cron "55 11 * * *" --tz "America/Chicago" \
+  --session isolated --delivery-mode none \
+  --model cheap --timeout-seconds 300 \
+  --message "Run the budget-guard daily pass. Read workflows/budget-guard/AGENT.md and follow it."
+```
+
+First run lives in dry-run mode. Edit `rules.md`:
+
+- Set per-cron caps under `budgets:` after one run shows you what real spend
+  looks like.
+- Flip `mode: dry_run` → `mode: enforce` after 3 days of clean dry-run output.
+
+## Rolling back
+
+- Disable the cron: `openclaw cron remove <id>`.
+- Re-enable a cron that budget-guard disabled:
+  `openclaw cron update <id> --enabled true`.
+- Logs persist in `workflows/budget-guard/logs/YYYY-MM.jsonl` even after the
+  workflow is removed.
+
+## Related
+
+- [Ecosystem Intel rollout](../memory/ventures/ecosystem-intel-rollout.md) — this
+  workflow is the first feature shipped through the test → friendlies → fleet
+  ladder.
+- [Paperclip](https://paperclip.ing/) — upstream concept source. We do not
+  depend on Paperclip at runtime.

--- a/workflows/budget-guard/AGENT.md
+++ b/workflows/budget-guard/AGENT.md
@@ -1,0 +1,176 @@
+---
+name: budget-guard
+version: 0.1.0
+description:
+  Per-agent and per-cron monthly spend caps with automatic disable on breach.
+  Feature pulled from paperclipai/paperclip's "Cost Control" primitive and adapted
+  to the OpenClaw fleet shape.
+source_upstream: paperclipai/paperclip @ 2026-04-22
+source_feature: "Monthly budgets per agent. When they hit the limit, they stop."
+---
+
+# Budget Guard
+
+You are the fleet's circuit breaker on LLM spend. Every cron and every long-running
+session has a declared monthly budget. When a job crosses its cap, you disable it and
+report the breach. When a job approaches its cap, you warn. When nothing is wrong, you
+stay silent.
+
+`llm-usage-report` reports what happened. Budget guard **prevents** what shouldn't
+happen. That is the difference.
+
+## Why this exists
+
+Paperclip ships "Monthly budgets per agent. When they hit the limit, they stop."
+We already gather cost data daily in `llm-usage-report`, but we never act on it.
+A single mis-written prompt in a frequent cron can burn hundreds of dollars before
+the next day's report lands on Nick's plate. Budget guard closes that loop.
+
+## Definition of Done
+
+### Verification Level: B (self-score + circuit breakers)
+
+This workflow mutates cron state (can disable a cron). All mutations are reversible
+by re-enabling, and every mutation is logged with the reason + spend numbers.
+
+### Completion Criteria
+
+- Monthly spend per cron / per agent label was computed for the current calendar
+  month up to now
+- Each cron with a declared budget in `rules.md#budgets` was checked
+- Crons at ≥ 100% of cap were disabled via `openclaw cron update` (or logged for
+  manual disable when the CLI is not available)
+- Crons at ≥ 80% of cap got a single warning in the Automation topic (dedupe: one
+  warning per cron per day)
+- Breach + warning events were written to `logs/YYYY-MM.jsonl`
+- A short summary was delivered to the Automation topic only if anything actually
+  happened (silent on quiet days)
+
+### Output Validation
+
+- No cron is disabled that is not named in `rules.md#budgets`
+- No cron is disabled without a breach log entry
+- The hard global cap (`rules.md#global_monthly_cap`) pauses ALL non-essential
+  crons if exceeded, not just the highest spender
+
+### Circuit Breakers
+
+- **Overreach breaker:** never disable more than 3 crons in a single run. If more
+  would trip, pause, alert the human, and stop.
+- **Essential breaker:** the list in `rules.md#essential_crons` can never be
+  auto-disabled. They warn-only.
+- **Data-gap breaker:** if the spend source (`openclaw cost` / session data)
+  returned an error or empty set, do NOT act. Warn instead.
+
+## Architecture
+
+Three phases, each cheap:
+
+```
+AGGREGATE  →  EVALUATE  →  ACT
+(cheap)       (cheap)       (cheap + mutation-gated)
+daily 11:55   daily 11:55   daily 11:55 (right before llm-usage-report)
+```
+
+### Phase 1 — Aggregate
+
+Run `openclaw cost --since month-start --by cron --json` (or equivalent session
+data query). Produce a map: `{cron_id: usd_spent_this_month}`. Include a second
+map for `{agent_label: usd_spent_this_month}`. Write to
+`logs/aggregate-YYYY-MM-DD.json`.
+
+### Phase 2 — Evaluate
+
+For each entry in `rules.md#budgets`:
+
+- Look up actual spend from Phase 1
+- Compute `pct = spent / cap`
+- Classify: `ok` (<80%), `warn` (80–99%), `breach` (≥100%)
+
+Produce a decision list. Essential crons are never marked `breach`; they cap at
+`warn` with an explicit note.
+
+### Phase 3 — Act
+
+For each `breach` decision:
+
+1. Check the overreach breaker — if this would be the 4th disable in the run, stop.
+2. Run `openclaw cron update <id> --enabled false` and capture the response.
+3. Append to `logs/YYYY-MM.jsonl` with `{date, cron_id, spent, cap, action:
+   "disabled", reason}`.
+4. Add to the outbound summary.
+
+For each `warn` decision (not already warned today):
+
+1. Append to `logs/YYYY-MM.jsonl` with `{action: "warned"}`.
+2. Add to the outbound summary.
+
+If the outbound summary is empty, deliver nothing. Otherwise, post to Telegram
+Automation topic:
+
+```
+💰 Budget Guard — YYYY-MM-DD
+
+Disabled (N):
+  • <cron-name> — $X.XX / $Y.YY cap (Z%) — disabled. Re-enable: openclaw cron update <id> --enabled true
+Warnings (M):
+  • <cron-name> — $X.XX / $Y.YY cap (Z%)
+
+Total month-to-date: $A.AA / $B.BB global cap
+```
+
+## Cron Setup
+
+One daily check at 11:55 CT, just before `llm-usage-report` at noon so the report
+can reflect any actions taken.
+
+```bash
+openclaw cron add --name "budget-guard-daily" \
+  --cron "55 11 * * *" --tz "America/Chicago" \
+  --session isolated --delivery-mode none \
+  --model cheap --timeout-seconds 300 \
+  --message "Run the budget-guard daily pass. Read workflows/budget-guard/AGENT.md and follow it."
+```
+
+The workflow itself posts to the Automation topic when there is something to say;
+`--delivery-mode none` avoids a second message from the cron runner.
+
+## First Run — Setup
+
+1. Populate `rules.md#budgets` with starting caps. Err on the side of generous for
+   the first month; the goal is to catch runaways, not to micro-manage normal spend.
+2. Run once in dry-run mode (`--dry-run` flag described in `scripts/aggregate.sh`)
+   and confirm the decision list looks right.
+3. Enable the cron only after Nick has seen one dry-run output.
+
+## Rollout Pipeline (per ecosystem-intel-rollout.md)
+
+- **Rung 1 (Nick's box, ≥3 days dry-run):** cron runs, writes logs, emits summary,
+  but every `disable` is a no-op (logged as `action: "would-disable"`). Nick reads
+  the output for 3 mornings.
+- **Rung 2 (friendlies, Åsa opt-in):** enable real disable on Nick's fleet, plus
+  one friendly fleet. Two weeks of clean operation.
+- **Rung 3 (full fleet):** merge to openclaw-config main, include in next release.
+- **Rung 4 (graduate):** after 20 disable events across fleet at ≥ 80% correct
+  classification, the `monthly_cap_enforcement` class can go tier-5 auto-apply in
+  ecosystem-intel.
+
+## Rollback
+
+Reversible at every rung:
+
+- Phase 1–2 are read-only. Safe to run.
+- Phase 3 disables crons. To re-enable: `openclaw cron update <id> --enabled true`.
+- To disable the whole workflow: remove the `budget-guard-daily` cron. The logs
+  persist so re-enabling later keeps history.
+
+## Attribution
+
+This workflow is a minimal port of Paperclip's "Cost Control" primitive:
+
+> "Monthly budgets per agent. When they hit the limit, they stop. No runaway costs."
+> — paperclip.ing/llms.txt
+
+Paperclip enforces this at their control-plane level; we enforce it at the cron
+level, which matches the fleet's actual unit of deployment. We do not depend on
+Paperclip at runtime.

--- a/workflows/budget-guard/agent_notes.md
+++ b/workflows/budget-guard/agent_notes.md
@@ -1,0 +1,23 @@
+# Budget Guard — Agent Notes
+
+Running learnings, exceptions, and corrections specific to this workflow's instance.
+The `learning-loop` workflow may also append here.
+
+## 2026-04-22 — v0.1.0 created
+
+Pulled from `paperclipai/paperclip` Cost Control primitive. Selected because it is
+the highest-leverage primitive Paperclip ships that we do not already have in some
+form. `llm-usage-report` covers reporting; budget-guard covers prevention.
+
+Designed deliberately to start in `dry_run` mode so the first 3 mornings produce
+human-readable output without disabling anything. Nick reviews the decision list,
+then flips `mode: enforce`.
+
+## Failures
+
+None yet — first run pending.
+
+## Auto-applied
+
+None — auto-apply class `monthly_cap_enforcement` is not yet listed in
+`workflows/ecosystem-intel/rules.md#auto_apply_classes`.

--- a/workflows/budget-guard/rules.md
+++ b/workflows/budget-guard/rules.md
@@ -1,0 +1,79 @@
+# Budget Guard — Instance Rules
+
+Per-fleet configuration for `budget-guard`. This file is instance-owned and is NOT
+overwritten by `openclaw-config` updates once it exists.
+
+## Delivery
+
+- **Channel:** `telegram`
+- **Target chat:** `469214633`
+- **Topic:** `70103` (📋 Automation)
+
+## Mode
+
+- `mode: dry_run` — set to `enforce` only after Nick has seen at least 3 days of
+  dry-run output and approved the decision list.
+
+## Global cap
+
+- `global_monthly_cap_usd: 200` — start generous; the report shows real spend has
+  been well under this. Adjust after one month.
+
+## Essential crons (warn-only, never auto-disabled)
+
+These crons are load-bearing for the fleet's ability to keep running. They can
+generate warnings but `budget-guard` will never disable them automatically.
+
+- `cron-healthcheck`
+- `budget-guard-daily` (this workflow itself)
+- `llm-usage-report`
+- `security-sentinel-*`
+- Any cron whose name contains `forward-motion` (drives stuck-thread recovery)
+
+## Per-cron budgets
+
+Format:
+
+```yaml
+- cron_id: <uuid>
+  name: <human name>
+  monthly_cap_usd: <number>
+  notes: <why this cap>
+```
+
+Starting list — populate after the first dry-run shows real spend per cron:
+
+```yaml
+budgets:
+  # Filled in after first dry-run aggregate. Until then, only the global cap
+  # applies and individual crons cannot be auto-disabled.
+  []
+```
+
+## Per-agent-label budgets
+
+For long-running named sessions (Cora's main thread, sub-agent labels). Same
+shape as cron budgets:
+
+```yaml
+agent_budgets:
+  - label: "cora-main"
+    monthly_cap_usd: 100
+    notes: "Cora's main session — generous, this is the primary surface."
+  - label: "ecosystem-intel-*"
+    monthly_cap_usd: 25
+    notes: "All ecosystem-intel sub-agents combined."
+```
+
+## Hard rules
+
+- Never disable a cron not named in `budgets:`.
+- Never disable an `essential_crons` entry.
+- Never act on data older than 24 hours.
+- Always log the spend numbers that triggered the action.
+- Default to inaction when uncertain.
+
+## Pilot cohort
+
+- `pilot_cohort: [nick]` until rung 2.
+- Add `asa` after rung 1 passes ≥ 3 days dry-run with no false-positive disables.

--- a/workflows/budget-guard/scripts/aggregate.sh
+++ b/workflows/budget-guard/scripts/aggregate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# budget-guard/scripts/aggregate.sh
+#
+# Phase 1: pull month-to-date LLM spend, grouped by cron_id and by agent label.
+# Writes a single JSON blob to stdout. Safe to dry-run.
+#
+# Usage:
+#   ./aggregate.sh [--dry-run]
+#
+# Assumes `openclaw` CLI is on PATH and has a `cost` subcommand with --json.
+# If the subcommand is missing, falls back to reading
+# ~/.openclaw/agents/*/sessions/*.jsonl and summing `estimatedCostUsd` fields.
+
+set -euo pipefail
+
+MONTH_START=$(date -v1d +%Y-%m-%d 2>/dev/null || date -d "$(date +%Y-%m-01)" +%Y-%m-%d)
+TODAY=$(date +%Y-%m-%d)
+
+# Preferred path: official CLI
+if openclaw cost --help >/dev/null 2>&1; then
+  openclaw cost --since "${MONTH_START}" --until "${TODAY}" --by cron --json
+  exit 0
+fi
+
+# Fallback: walk session transcripts and sum estimatedCostUsd
+SESS_DIR="${HOME}/.openclaw/agents"
+if [[ ! -d "${SESS_DIR}" ]]; then
+  echo '{"error":"no-session-data","month_start":"'"${MONTH_START}"'"}'
+  exit 2
+fi
+
+python3 - <<'PY'
+import json, os, sys, datetime, glob, re
+
+home = os.path.expanduser("~")
+month_start = datetime.date.today().replace(day=1)
+totals_by_cron = {}
+totals_by_agent = {}
+
+for path in glob.glob(os.path.join(home, ".openclaw/agents/*/sessions/*.jsonl")):
+    mtime = datetime.date.fromtimestamp(os.path.getmtime(path))
+    if mtime < month_start:
+        continue
+    cron_id = None
+    agent_label = None
+    cost = 0.0
+    try:
+        with open(path, "r") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except Exception:
+                    continue
+                if isinstance(row, dict):
+                    if "estimatedCostUsd" in row:
+                        try:
+                            cost += float(row["estimatedCostUsd"])
+                        except Exception:
+                            pass
+                    if not cron_id:
+                        m = re.search(r"cron:([0-9a-f-]{36})", json.dumps(row))
+                        if m:
+                            cron_id = m.group(1)
+                    if not agent_label:
+                        lbl = row.get("label") or row.get("agent_label")
+                        if lbl:
+                            agent_label = lbl
+    except Exception:
+        continue
+    if cost <= 0:
+        continue
+    if cron_id:
+        totals_by_cron[cron_id] = totals_by_cron.get(cron_id, 0.0) + cost
+    if agent_label:
+        totals_by_agent[agent_label] = totals_by_agent.get(agent_label, 0.0) + cost
+
+json.dump({
+    "month_start": month_start.isoformat(),
+    "generated_at": datetime.datetime.now().isoformat(),
+    "by_cron": {k: round(v, 4) for k, v in totals_by_cron.items()},
+    "by_agent": {k: round(v, 4) for k, v in totals_by_agent.items()},
+}, sys.stdout, indent=2)
+PY

--- a/workflows/budget-guard/scripts/evaluate.py
+++ b/workflows/budget-guard/scripts/evaluate.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""budget-guard/scripts/evaluate.py
+
+Phase 2: read aggregate JSON on stdin, rules.md budgets (passed as --rules),
+and produce a decision list on stdout.
+
+Decision shape:
+  {
+    "ok":      [{"name":..., "spent":..., "cap":..., "pct":...}, ...],
+    "warn":    [...],
+    "breach":  [...],
+    "essential_warn": [...],  # breach-level spend but listed as essential -> warn only
+    "global": {"spent":..., "cap":..., "pct":..., "status":"ok|warn|breach"}
+  }
+
+Does not mutate anything. Safe to run anytime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def parse_rules(rules_path: Path) -> dict:
+    """Minimal YAML-ish parser for the fields we need, no external deps."""
+    text = rules_path.read_text()
+    out = {
+        "global_cap": 200.0,
+        "mode": "dry_run",
+        "essential": [],
+        "budgets": [],
+        "agent_budgets": [],
+    }
+    m = re.search(r"global_monthly_cap_usd:\s*([0-9.]+)", text)
+    if m:
+        out["global_cap"] = float(m.group(1))
+    m = re.search(r"^mode:\s*([a-z_]+)", text, re.MULTILINE)
+    if m:
+        out["mode"] = m.group(1)
+    # essential list: lines in the Essential section starting with `- `
+    in_essential = False
+    for line in text.splitlines():
+        if line.startswith("## Essential crons"):
+            in_essential = True
+            continue
+        if in_essential and line.startswith("## "):
+            in_essential = False
+        if in_essential and line.strip().startswith("- "):
+            out["essential"].append(line.strip()[2:].strip("`"))
+    # budgets block (very small parser — expects already-simple yaml)
+    in_budgets = False
+    cur = None
+    for line in text.splitlines():
+        if "budgets:" in line and "agent_budgets" not in line:
+            in_budgets = True
+            continue
+        if in_budgets and line.startswith("agent_budgets:"):
+            in_budgets = False
+        if in_budgets:
+            s = line.strip()
+            if s.startswith("- cron_id:"):
+                if cur:
+                    out["budgets"].append(cur)
+                cur = {"cron_id": s.split(":", 1)[1].strip()}
+            elif cur is not None and ":" in s and not s.startswith("- "):
+                k, v = s.split(":", 1)
+                cur[k.strip()] = v.strip().strip('"')
+    if cur:
+        out["budgets"].append(cur)
+    return out
+
+
+def is_essential(name: str, essentials: list[str]) -> bool:
+    for pat in essentials:
+        if pat in name or re.search(pat.replace("*", ".*"), name):
+            return True
+    return False
+
+
+def classify(spent: float, cap: float) -> str:
+    if cap <= 0:
+        return "ok"
+    pct = spent / cap
+    if pct >= 1.0:
+        return "breach"
+    if pct >= 0.8:
+        return "warn"
+    return "ok"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rules", required=True)
+    args = ap.parse_args()
+
+    agg = json.load(sys.stdin)
+    rules = parse_rules(Path(args.rules))
+
+    decisions = {"ok": [], "warn": [], "breach": [], "essential_warn": []}
+    for b in rules["budgets"]:
+        cid = b.get("cron_id", "").strip()
+        name = b.get("name", cid)
+        cap = float(b.get("monthly_cap_usd", 0) or 0)
+        spent = float(agg.get("by_cron", {}).get(cid, 0.0))
+        status = classify(spent, cap)
+        rec = {"cron_id": cid, "name": name, "spent": round(spent, 2),
+               "cap": cap, "pct": round(spent / cap * 100, 1) if cap else 0}
+        if status == "breach" and is_essential(name, rules["essential"]):
+            rec["note"] = "essential — warn only"
+            decisions["essential_warn"].append(rec)
+        else:
+            decisions[status].append(rec)
+
+    total = sum(agg.get("by_cron", {}).values()) + sum(
+        v for k, v in agg.get("by_agent", {}).items()
+    )
+    gcap = rules["global_cap"]
+    decisions["global"] = {
+        "spent": round(total, 2),
+        "cap": gcap,
+        "pct": round(total / gcap * 100, 1) if gcap else 0,
+        "status": classify(total, gcap),
+    }
+    decisions["mode"] = rules["mode"]
+    json.dump(decisions, sys.stdout, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
Pulls Paperclip's Cost Control primitive ("Monthly budgets per agent. When they hit the limit, they stop.") into the fleet as a new `budget-guard` workflow.

## Why
`llm-usage-report` reports yesterday's spend at noon. By the time you see the report, a runaway cron has burned 24h of budget. `budget-guard` catches the runaway in-flight at 11:55 CT — five minutes before the report — and stops it.

## Source attribution
- Upstream: [paperclipai/paperclip](https://github.com/paperclipai/paperclip) (MIT)
- Concept doc: https://paperclip.ing/llms.txt — the "Cost Control" line
- We do NOT depend on Paperclip at runtime. Pattern only.

## Files
- `workflows/budget-guard/AGENT.md` — full spec, three phases, circuit breakers, rollout ladder
- `workflows/budget-guard/rules.md` — instance config, starts in dry-run mode
- `workflows/budget-guard/scripts/aggregate.sh` — month-to-date spend rollup (uses `openclaw cost`, falls back to walking session jsonl)
- `workflows/budget-guard/scripts/evaluate.py` — decision engine, no mutations
- `docs/budget-guard.md` — user-facing doc

## Safety
- Starts in `mode: dry_run` — no cron is disabled until Nick flips the flag
- 4 circuit breakers: overreach (max 3 disables/run), essential (load-bearing crons warn-only), data-gap (no act on bad data), global cap
- Every disable is reversible: `openclaw cron update <id> --enabled true`
- Logs persist under `workflows/budget-guard/logs/`

## Rollout (per ecosystem-intel-rollout.md)
- **Rung 1:** dry-run on Nick's box for ≥3 mornings
- **Rung 2:** enforce on Nick + Åsa for 2 weeks
- **Rung 3:** merge to main, fleet release
- **Rung 4:** graduate `monthly_cap_enforcement` class to ecosystem-intel auto-apply

## Testing
```
echo '{"month_start":"2026-04-01","by_cron":{"abc-123":15.50,"def-456":120.00},"by_agent":{"cora-main":45.00}}' \\
  | workflows/budget-guard/scripts/evaluate.py --rules workflows/budget-guard/rules.md
```
Returns valid decision JSON with global status `warn` at $180.50 / $200 cap. Verified locally.

## What this is the test of
This is the **first feature shipped through the ecosystem-intel scan→filter→test→rollout pipeline**. If this PR merges and runs cleanly for 3 days on Nick's machine, the pipeline has shipped one real upgrade end to end and we can run it again next week with a different feature.