### PR TITLE
fix(review): policy floors override never_run preference

### DIFF
--- a/skills/review/references/policy-floors.md
+++ b/skills/review/references/policy-floors.md
@@ -20,6 +20,10 @@ The combined floor decision (strictest verdict + union of required reviewers) is
 the gating LLM, which must respect it. Don't stop at the first match — an artifact
 that's both public-facing and financial needs both floors applied.
 
+**Floor-required lenses override `never_run`.** If the operator's `rules.md` lists a
+lens in `never_run` but a matching floor requires it, the floor wins. Safety floors
+exist precisely because some checks cannot be skipped by preference.
+
 If any floor produces a hard `block`, the orchestrator returns immediately without
 running the panel.
 

--- a/skills/review/references/setup.md
+++ b/skills/review/references/setup.md
@@ -134,8 +134,8 @@ Then proceed with the actual review the operator originally invoked.
 ## Lens Selection
 
 - always_run: [empathy]
-- never_run: [] # lenses to suppress entirely (use sparingly, the gating LLM is usually
-  right)
+- never_run: [] # lenses to suppress entirely (policy floors override this; use
+  sparingly)
 
 ## Custom Lenses
 
@@ -157,6 +157,7 @@ preferences as soft constraints in the gating prompt:
 >
 > - posture: <value> → adjust how many lenses you select
 > - always_run: <list> → include these in `lenses` no matter what
-> - never_run: <list> → exclude these from `lenses`
+> - never_run: <list> → exclude these from `lenses` (policy floors override this — if a
+>   floor requires a lens, it runs even if listed in `never_run`)
 > - custom_lens_dir contents: <list of .md files found> → consider including by name
 >   when relevant


### PR DESCRIPTION
## Summary

- Adds explicit precedence rule: policy floor-required lenses override the operator's `never_run` preference
- Documents in both `policy-floors.md` (the authoritative source) and `setup.md` (the gating prompt injection)
- Updates the `rules.md` template comment to note the override

## Context

From PR #115 bot review sweep. Cursor correctly identified that an operator could set `never_run: [evidence]` while the money floor mandates `evidence`, creating contradictory instructions with no documented precedence. Safety floors exist precisely because some checks cannot be skipped by preference.

## Changes

- `skills/review/references/policy-floors.md` — added "Floor-required lenses override `never_run`" paragraph
- `skills/review/references/setup.md` — added override note in gating prompt injection and rules.md template

## Test plan

- [x] Verify policy-floors.md states the precedence rule clearly
- [x] Verify setup.md gating prompt injection mentions the override
- [x] Verify rules.md template comment notes the override

## PR #115 Bot Feedback Summary

**9 comments processed** (2 Codex, 7 Cursor):
- **Fixed: 1** — `never_run` vs floor-required lens precedence (Cursor)
- **Declined: 8** — fabricated quotes (3), misread existing text (2), stale post-merge feedback (2), explicit exception ignored (1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)