### PR TITLE
fix(claude-code): address bot feedback from PR #113

### DIFF
--- a/skills/claude-code/SKILL.md
+++ b/skills/claude-code/SKILL.md
@@ -31,8 +31,9 @@ operator says it, this skill applies — full stop.
 
 Secondary trigger: any request to edit, fix, refactor, or open a PR in a repo **with
 reviewers or that goes through PRs** — meaning any repo that is not
-`~/.openclaw/workspace`. Even if Nick doesn't say "claude code" by name, treat PR-bound
-repo work as a Claude Code job.
+`~/.openclaw/workspace` (and excluding other non-PR paths listed below). Even if the
+operator doesn't say "claude code" by name, treat PR-bound repo work as a Claude Code
+job.
 
 ## When to use this skill
 


### PR DESCRIPTION
## Summary

- Remove hardcoded "Nick" from skill docs — replaced with "the operator" per zero-PII policy
- Clarify secondary trigger scope to reference exclusion list below, resolving contradiction with `~/clawd` exclusion

Addresses bot review comments from PR #113:
- **Codex**: correctly flagged PII leak (operator name in public template)
- **Cursor**: correctly identified trigger/exclusion contradiction for `~/clawd`
- **Codex** (declined): incorrectly claimed bare `/multi-review` was used — all slash commands were already namespaced

## Test plan

- [x] Verify no PII remains in `skills/claude-code/SKILL.md`
- [x] Verify secondary trigger text references exclusion list
- [ ] Pre-commit checks pass
- [ ] Bot reviews clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)