### PR TITLE
fix(cron-healthcheck): address PR #112 bot review feedback

### DIFF
--- a/workflows/cron-healthcheck/AGENT.md
+++ b/workflows/cron-healthcheck/AGENT.md
@@ -89,10 +89,11 @@ Every cycle follows this pattern:
 
 1. **Survey** — List all cron jobs (including disabled ones) via the cron tool
 2. **Detect (hard failure)** — Check each enabled job for `consecutiveErrors >= 2`
-3. **Detect (semantic failure)** — Read recent run summaries and judge each job
-4. **Branch** — If all healthy, reply `HEARTBEAT_OK` and stop. If any broken, escalate.
+3. **Read prior corrections** — Check `agent_notes.md` for learned patterns
+4. **Detect (semantic failure)** — Read recent run summaries and judge each job
+5. **Branch** — If all healthy, reply `HEARTBEAT_OK` and stop. If any broken, escalate.
 
-Run both detection steps before branching, even if step 2 already found hard failures —
+Run all detection steps before branching, even if step 2 already found hard failures —
 the sub-agent needs the full picture to distinguish hard-only from hard+semantic jobs.
 
 You do NOT remediate. You do NOT diagnose. You detect and delegate.
@@ -111,7 +112,16 @@ For each enabled job, check `consecutiveErrors >= 2`. (Lowered from 3 to 2 so we
 one cycle earlier — a single transient blip still gets a pass, but a repeating error
 triggers investigation.)
 
-### 3. Semantic-failure path — use your judgment
+### 3. Read prior corrections
+
+Before making semantic judgments, read `agent_notes.md` and check the **Judgment
+corrections** and **Failures & Corrections** sections. These record patterns where
+previous runs misjudged healthy no-ops as failures. Let these guide your judgment in
+step 4 so you don't repeat the same mistakes.
+
+If `agent_notes.md` does not exist yet, skip this step.
+
+### 4. Semantic-failure path — use your judgment
 
 For each enabled job, read the last 5 `finished` entries from
 `~/.openclaw/cron/runs/<jobId>.jsonl`. If the file does not exist (new job, no runs
@@ -121,7 +131,7 @@ The JSONL file has one record per line with varying `action` values. Only `finis
 records contain a `summary` field. A reliable way to extract them:
 
 ```
-grep '"action":"finished"' ~/.openclaw/cron/runs/<jobId>.jsonl | tail -n 5
+grep '"action": *"finished"' ~/.openclaw/cron/runs/<jobId>.jsonl | tail -n 5
 ```
 
 Then parse out the `summary` field from each line.
@@ -161,13 +171,13 @@ emoji-laden, context-dependent. A keyword list can't distinguish
 - "Weekly review: 19 tasks completed this week" (normal content that happens to mention
   numbers or "completed")
 
-### 4. Decide
+### 5. Decide
 
 A job is **semantically failing** when, in your honest judgment, **2 or more of the last
 5 finished runs show the agent reporting it could not do its job**. One bad run could be
 a transient blip; two establishes a pattern worth investigating.
 
-### 5. Combine and decide
+### 6. Combine and decide
 
 Build a union of hard-failing and semantically-failing jobs.
 


### PR DESCRIPTION
## Summary

Addresses bot review feedback from PR #112 (merged):

- **Add Step 3 "Read prior corrections"** to the detection workflow so agents read `agent_notes.md` Judgment corrections before making semantic judgments — previously this was only in the State Management section, not the numbered flow (Cursor catch)
- **Fix grep pattern spacing** — `"action":"finished"` → `"action": *"finished"` to handle both compact and standard JSON formatting (Cursor catch)
- **Declined Codex P1** — bot claimed an "allow-list" mechanism exists that could suppress real incidents, but the design uses LLM judgment with no allow-list

## PR #112 Bot Comment Triage

| Bot | Comment | Verdict | Action |
|-----|---------|---------|--------|
| `chatgpt-codex-connector[bot]` | P1: Allow-list skips too broad | Incorrect | Declined — no allow-list exists in the design |
| `cursor[bot]` | Judgment corrections read step missing from flow | Valid | Fixed — added Step 3 |
| `cursor[bot]` | Grep pattern assumes compact JSON | Valid | Fixed — pattern now handles spacing |

## Test plan

- [x] Verify step numbering is consistent (overview matches detailed sections)
- [x] Verify grep pattern handles both `"action":"finished"` and `"action": "finished"`
- [x] Verify new Step 3 references correct sections of agent_notes.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)