### PR TITLE
fix(app-router): encode next param in Caddy 401 redirect

### DIFF
--- a/devops/app-router/templates/Caddyfile.example
+++ b/devops/app-router/templates/Caddyfile.example
@@ -36,7 +36,10 @@
             copy_headers Cookie
             @unauthorized status 401
             handle_response @unauthorized {
-                redir * /auth/login?app=my-private-app&next={http.request.uri} 302
+                # {http.request.uri.path} avoids encoding `&` from query strings
+                # breaking the `next` parameter. Query params are not preserved
+                # in the redirect; after login the user lands at the page root.
+                redir * /auth/login?app=my-private-app&next={http.request.uri.path} 302
             }
         }
         uri strip_prefix /my-private-app


### PR DESCRIPTION
## Summary

- Fixes Caddyfile template bug from Cursor Bugbot review of PR #121 (commit `faca4c9`)
- `{http.request.uri}` includes raw query strings with literal `&` characters; when used as the value of `next=` in a redirect URL, those `&` chars get parsed as additional query parameters instead of part of `next`, truncating the redirect path
- Switched to `{http.request.uri.path}` which is always free of `&` — Caddy has no built-in URI-encoding modifier for placeholder values in `redir` directives
- Trade-off: query parameters from the original URL are not preserved after login (user lands at the page root rather than the exact page+params); this is the correct safe default for a template

## Bot feedback addressed from PR #121

- **Fixed (1)**: Caddyfile `&` query param truncation (Cursor Bugbot, LOW severity)
- **Declined/Incorrect (3)**: Three other bot comments flagged bugs already addressed in the final merged code:
  - `sed "s|&lt;USER&gt;|$USER|g"` already uses the correct XML-encoded pattern (cursor: plist sed match)
  - `safeNext` already decodes + checks both raw and percent-encoded traversal (cursor: path traversal)
  - `copy_if_absent` already does `rm -rf "$dst"` before `cp -R` when forcing (codex: cp -R directory nesting)

## Test plan

- [ ] Review Caddyfile.example diff — `{http.request.uri.path}` in the `redir` directive
- [ ] Verify no other Caddyfile templates use the raw `{http.request.uri}` in a query param context

🤖 Generated with [Claude Code](https://claude.com/claude-code)