### PR TITLE
devops/app-router: per-app password-protected web app router

### DIFF
--- a/devops/app-router/README.md
+++ b/devops/app-router/README.md
@@ -32,7 +32,7 @@ The deploy target on each machine is `~/openclaw-apps/`:
 ~/openclaw-apps/
   ecosystem.config.js              copy of templates/ecosystem.config.js.example
   auth-service/                    copy of devops/app-router/auth-service/
-  _registry/
+  router/
     Caddyfile                      copy of templates/Caddyfile.example
     restore-tailscale-serve.sh     copy of scripts/restore-tailscale-serve.sh
     logs/                          stdout/stderr for the launchd plist
@@ -59,15 +59,15 @@ Re-running is safe; existing files are skipped. Pass `--force` to overwrite.
 
 Edit `~/openclaw-apps/ecosystem.config.js` — set `AUTH_SECRET` (use
 `openssl rand -hex 32`), and fill in `APP_PASSWORD_<SLUG>`, `APP_TITLE_<SLUG>`, and
-`APP_DESC_<SLUG>` for any protected apps. Then edit
-`~/openclaw-apps/_registry/Caddyfile` to match.
+`APP_DESC_<SLUG>` for any protected apps. Then edit `~/openclaw-apps/router/Caddyfile`
+to match.
 
 Start everything under PM2:
 
 ```
 pm2 start ~/openclaw-apps/ecosystem.config.js
 pm2 start /opt/homebrew/bin/caddy --name caddy --interpreter none -- \
-  run --config ~/openclaw-apps/_registry/Caddyfile --adapter caddyfile
+  run --config ~/openclaw-apps/router/Caddyfile --adapter caddyfile
 pm2 save
 pm2 startup     # then run the printed sudo command
 ```
@@ -110,7 +110,7 @@ After editing both files:
 
 ```
 pm2 restart ecosystem.config.js          # or just `pm2 restart auth-service` for password-only changes
-caddy reload --config ~/openclaw-apps/_registry/Caddyfile --adapter caddyfile
+caddy reload --config ~/openclaw-apps/router/Caddyfile --adapter caddyfile
 ```
 
 The app is immediately live at `https://<host>:4242/<slug>/`.

--- a/devops/app-router/launchd/ai.openclaw.app-router-serve.plist
+++ b/devops/app-router/launchd/ai.openclaw.app-router-serve.plist
@@ -4,7 +4,7 @@
     Restores Tailscale Serve config for the OpenClaw app router on boot.
 
     Install: copy devops/app-router/scripts/restore-tailscale-serve.sh into
-    ~/openclaw-apps/_registry/restore-tailscale-serve.sh (chmod +x), then copy
+    ~/openclaw-apps/router/restore-tailscale-serve.sh (chmod +x), then copy
     this plist into ~/Library/LaunchAgents/ — substituting <USER> for your
     macOS username — and `launchctl bootstrap gui/$(id -u) <plist>`.
 
@@ -23,7 +23,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>/Users/&lt;USER&gt;/openclaw-apps/_registry/restore-tailscale-serve.sh</string>
+        <string>/Users/&lt;USER&gt;/openclaw-apps/router/restore-tailscale-serve.sh</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>
@@ -35,8 +35,8 @@
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/Users/&lt;USER&gt;/openclaw-apps/_registry/logs/tailscale-serve.log</string>
+    <string>/Users/&lt;USER&gt;/openclaw-apps/router/logs/tailscale-serve.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/&lt;USER&gt;/openclaw-apps/_registry/logs/tailscale-serve-error.log</string>
+    <string>/Users/&lt;USER&gt;/openclaw-apps/router/logs/tailscale-serve-error.log</string>
 </dict>
 </plist>

--- a/devops/app-router/scripts/install.sh
+++ b/devops/app-router/scripts/install.sh
@@ -29,15 +29,33 @@ copy_if_absent() {
     fi
 }
 
+render_if_absent() {
+    local src="$1" dst="$2"
+    if [ -e "$dst" ] && [ "$FORCE" != "1" ]; then
+        echo "  skip (exists): $dst"
+    else
+        if ! grep -q '<OPENCLAW_APPS_DIR>' "$src"; then
+            echo "ERROR: placeholder <OPENCLAW_APPS_DIR> not found in $src" >&2
+            exit 1
+        fi
+        local tmp
+        tmp="$(mktemp "${dst}.XXXXXX")"
+        sed "s|<OPENCLAW_APPS_DIR>|$DEST|g" "$src" > "$tmp"
+        mv "$tmp" "$dst"
+        echo "  wrote: $dst"
+    fi
+}
+
 echo "[install] source: $SRC"
 echo "[install] target: $DEST"
 
-mkdir -p "$DEST/_registry/logs"
+mkdir -p "$DEST/router/logs" "$DEST/router/public"
 copy_if_absent "$SRC/auth-service" "$DEST/auth-service"
 copy_if_absent "$SRC/templates/ecosystem.config.js.example" "$DEST/ecosystem.config.js"
-copy_if_absent "$SRC/templates/Caddyfile.example" "$DEST/_registry/Caddyfile"
-copy_if_absent "$SRC/scripts/restore-tailscale-serve.sh" "$DEST/_registry/restore-tailscale-serve.sh"
-chmod +x "$DEST/_registry/restore-tailscale-serve.sh"
+render_if_absent "$SRC/templates/Caddyfile.example" "$DEST/router/Caddyfile"
+copy_if_absent "$SRC/templates/index.html" "$DEST/router/public/index.html"
+copy_if_absent "$SRC/scripts/restore-tailscale-serve.sh" "$DEST/router/restore-tailscale-serve.sh"
+chmod +x "$DEST/router/restore-tailscale-serve.sh"
 
 echo "[install] installing auth-service deps"
 (cd "$DEST/auth-service" && npm install --omit=dev --silent --no-audit --no-fund)
@@ -63,9 +81,9 @@ cat <<EOF
 Next steps:
   1. Edit $DEST/ecosystem.config.js — set AUTH_SECRET (openssl rand -hex 32)
      and any APP_PASSWORD_<SLUG> / APP_TITLE_<SLUG> / APP_DESC_<SLUG> entries.
-  2. Edit $DEST/_registry/Caddyfile to match.
+  2. Edit $DEST/router/Caddyfile to match.
   3. pm2 start $DEST/ecosystem.config.js && pm2 save
   4. pm2 start /opt/homebrew/bin/caddy --name caddy --interpreter none -- \\
-       run --config $DEST/_registry/Caddyfile --adapter caddyfile
+       run --config $DEST/router/Caddyfile --adapter caddyfile
   5. tailscale serve --bg --https=4242 http://127.0.0.1:8080
 EOF

--- a/devops/app-router/scripts/install.sh
+++ b/devops/app-router/scripts/install.sh
@@ -38,9 +38,10 @@ render_if_absent() {
             echo "ERROR: placeholder <OPENCLAW_APPS_DIR> not found in $src" >&2
             exit 1
         fi
-        local tmp
+        local escaped_dest tmp
+        escaped_dest="$(printf '%s' "$DEST" | sed 's/[&\\|]/\\&/g')"
         tmp="$(mktemp "${dst}.XXXXXX")"
-        sed "s|<OPENCLAW_APPS_DIR>|$DEST|g" "$src" > "$tmp"
+        sed "s|<OPENCLAW_APPS_DIR>|${escaped_dest}|g" "$src" > "$tmp"
         mv "$tmp" "$dst"
         echo "  wrote: $dst"
     fi

--- a/devops/app-router/templates/Caddyfile.example
+++ b/devops/app-router/templates/Caddyfile.example
@@ -43,10 +43,12 @@
         reverse_proxy 127.0.0.1:3002
     }
 
-    # ── Catch-all index. Replace with your own landing page if you want a
-    #    directory of apps. Anything not matched above lands here. ────────
+    # ── Catch-all app index. Anything not matched above lands here.
+    #    Rooted at router/public so the rendered Caddyfile, restore
+    #    scripts, and logs stay out of the public web root. ─────────────
     handle {
-        header Content-Type "text/html; charset=utf-8"
-        respond `<!doctype html><html><body><h1>App Router</h1><p>No app at this path.</p></body></html>` 200
+        root * <OPENCLAW_APPS_DIR>/router/public
+        try_files {path} /index.html
+        file_server
     }
 }

--- a/devops/app-router/templates/Caddyfile.example
+++ b/devops/app-router/templates/Caddyfile.example
@@ -47,7 +47,7 @@
     #    Rooted at router/public so the rendered Caddyfile, restore
     #    scripts, and logs stay out of the public web root. ─────────────
     handle {
-        root * <OPENCLAW_APPS_DIR>/router/public
+        root * "<OPENCLAW_APPS_DIR>/router/public"
         try_files {path} /index.html
         file_server
     }

--- a/devops/app-router/templates/index.html
+++ b/devops/app-router/templates/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenClaw Apps</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      color-scheme: light;
+      --bg: #f8fafc;
+      --panel: #ffffff;
+      --ink: #0f172a;
+      --muted: #64748b;
+      --line: #e2e8f0;
+      --soft: #f1f5f9;
+      --accent: #4f46e5;
+      --accent-soft: #eef2ff;
+      --shadow: 0 18px 50px rgba(15, 23, 42, 0.08);
+    }
+    body {
+      min-height: 100vh;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at top left, rgba(79, 70, 229, 0.12), transparent 28rem),
+        radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.10), transparent 24rem),
+        var(--bg);
+      color: var(--ink);
+      padding: 56px 20px;
+    }
+    .wrap { max-width: 620px; margin: 0 auto; }
+    .hero {
+      background: rgba(255,255,255,0.82);
+      border: 1px solid rgba(226,232,240,0.9);
+      border-radius: 28px;
+      box-shadow: var(--shadow);
+      padding: 30px;
+      backdrop-filter: blur(10px);
+    }
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid var(--line);
+      background: var(--soft);
+      color: var(--muted);
+      border-radius: 999px;
+      padding: 7px 12px;
+      font-size: 13px;
+      margin-bottom: 18px;
+    }
+    h1 { font-size: clamp(30px, 5vw, 44px); line-height: 1.02; letter-spacing: -0.04em; margin-bottom: 12px; }
+    .subtitle { color: var(--muted); font-size: 16px; line-height: 1.55; max-width: 46rem; margin-bottom: 28px; }
+    .grid { display: grid; gap: 12px; }
+    .card {
+      display: block;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      padding: 18px 20px;
+      color: var(--ink);
+      text-decoration: none;
+      transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+    }
+    a.card:hover { transform: translateY(-1px); box-shadow: 0 12px 30px rgba(15, 23, 42, 0.10); border-color: #c7d2fe; }
+    .card-title { display: flex; align-items: center; justify-content: space-between; gap: 12px; font-size: 16px; font-weight: 700; margin-bottom: 5px; }
+    .card-desc { color: var(--muted); font-size: 14px; line-height: 1.45; }
+    .pill { flex: none; font-size: 12px; font-weight: 650; color: var(--accent); background: var(--accent-soft); border-radius: 999px; padding: 5px 9px; }
+    .muted-card { opacity: 0.78; }
+    .footer { color: #94a3b8; font-size: 12px; margin-top: 18px; text-align: center; }
+    @media (max-width: 520px) { body { padding: 28px 14px; } .hero { padding: 22px; border-radius: 22px; } }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <section class="hero">
+      <div class="eyebrow">🐾 Tailnet private app router</div>
+      <h1>OpenClaw App Router</h1>
+      <p class="subtitle">This host routes requests to private apps on your tailnet. Configure apps in <code>ecosystem.config.js</code> — they&rsquo;ll show up here as they come online.</p>
+      <div class="grid">
+        <a class="card" href="/health">
+          <div class="card-title">Router Health <span class="pill">Open</span></div>
+          <div class="card-desc">Quick liveness check for the local Caddy app router.</div>
+        </a>
+        <div class="card muted-card">
+          <div class="card-title">Your first app <span class="pill">Example</span></div>
+          <div class="card-desc">Replace this card with your own app. Set <code>APP_TITLE_&lt;SLUG&gt;</code> and <code>APP_DESC_&lt;SLUG&gt;</code> in <code>ecosystem.config.js</code>.</div>
+        </div>
+        <div class="card muted-card">
+          <div class="card-title">Your next app <span class="pill">Example</span></div>
+          <div class="card-desc">Each entry maps a URL path prefix to a local PM2 process. Add more by editing the Caddyfile and <code>ecosystem.config.js</code>.</div>
+        </div>
+      </div>
+    </section>
+    <p class="footer">OpenClaw App Router</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Builds a lightweight per-app web router for fleet machines: every named app gets a path like `/my-app/` on a single Tailscale HTTPS URL, with optional per-app password protection. PM2 keeps Node processes alive, Caddy routes paths to local ports and handles auth via `forward_auth`, and a small Express sidecar (`auth-service/`) issues scoped session cookies.

- **Auth model:** open / password-protected / no-password-configured. A per-app password sets a 7-day cookie scoped to that app's path only — knowing one password doesn't grant access to any other app. The login form addresses the user by the app's friendly name, not a slug.
- **Security defaults:** auth-service refuses to start in production without `AUTH_SECRET`; 30 req/IP/min rate limit on login; Origin/Referer CSRF check; timing-safe password compare; slug regex validation.
- **Idempotent installer:** `bash devops/app-router/scripts/install.sh` copies templates, installs deps, stages the launchd plist with the user's `$USER` substituted. Re-running is a no-op; `--force` overwrites. Renders the Caddyfile via `render_if_absent` (placeholder drift check + atomic mktemp+mv write).
- **Catch-all landing page:** real `index.html` served from `router/public/` — public assets kept out of the same dir as the rendered Caddyfile, restore script, and logs so they aren't directly fetchable over HTTP.
- **Boot persistence:** launchd plist re-applies Tailscale Serve on boot, since Serve config doesn't survive reboots.

## Review history

Branch has been through three rounds of review (multi-agent → bot → multi-agent). Notable fixes that landed: forward_auth CSRF + open-redirect guards, `AUTH_SECRET` enforcement in production, atomic Caddyfile rendering, file_server isolation from the rendered config dir.

## Test plan

- [ ] `bash devops/app-router/scripts/install.sh` on a fresh machine; re-run; re-run with `--force`
- [ ] `cd devops/app-router/auth-service && npm test`
- [ ] `curl https://<host>:4242/health` → `ok`
- [ ] Hit a password-protected app path → login form appears with the friendly title; correct password lets you in
- [ ] Knowing one app's password does not grant access to another app
- [ ] Hit an unmatched path → landing page renders (not the rendered Caddyfile)
- [ ] `curl https://<host>:4242/Caddyfile` → 404, not file contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)