### PR TITLE
fix(app-router): correct PM2 ecosystem env block JS syntax

### DIFF
--- a/devops/app-router/README.md
+++ b/devops/app-router/README.md
@@ -185,7 +185,7 @@ don't need to send auth themselves.
    the PM2 ecosystem env block in `ecosystem.config.js`:
    ```js
    env: {
-     OPENCLAW_HOOK_TOKEN: "your-token-here";
+     OPENCLAW_HOOK_TOKEN: "your-token-here",
    }
    ```
 2. Uncomment the `handle /hooks/* { ... }` block in the Caddyfile.


### PR DESCRIPTION
## Summary

- Fixes invalid JavaScript in the PM2 `ecosystem.config.js` code example in `devops/app-router/README.md`
- Changed trailing semicolon to trailing comma inside the `env: {}` object literal (semicolons are invalid in JS object literals)
- Without this fix, users copying the snippet get a PM2 parse error and `OPENCLAW_HOOK_TOKEN` never gets set, breaking the webhook bearer-injection flow

## Context

Caught by Codex review bot on PR #124 (already merged). One-line fix.

## Test plan

- [ ] Visually verify the code block in README renders correctly
- [ ] Confirm `ecosystem.config.js` with this snippet would parse without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)