### PR TITLE
fix(9router-health): move restart_command from required to optional schema

### DIFF
--- a/workflows/9router-health/AGENT.md
+++ b/workflows/9router-health/AGENT.md
@@ -122,9 +122,16 @@ Keep `CLAUDE.local.md` factual and machine-specific. It is gitignored.
 - `port: <local-port>`
 - `base_url: http://<host-or-ip>:<port>`
 - `log_dir: ~/path/to/9router/logs`
-- `restart_command: <local-service-restart-command>`
 - `stderr_log: ~/path/to/stderr.log`
 - `log_bloat_threshold_gb: <number>`
+
+### Optional schema
+
+These keys are recognized but not required. Missing optional keys do not trigger
+report-only mode:
+
+- `restart_command: <local-service-restart-command>` — reserved for future host-local
+  restart policy; automatic restarts are disabled until a policy is explicitly set
 
 Example shape only:
 
@@ -135,7 +142,6 @@ Example shape only:
 - port: <local-port>
 - base_url: http://<host-or-ip>:<port>
 - log_dir: ~/path/to/9router/logs
-- restart_command: <local-service-restart-command>
 - stderr_log: ~/path/to/stderr.log
 - log_bloat_threshold_gb: <number>
 
@@ -171,8 +177,8 @@ Do **not** put secrets, raw logs, personal names, private IDs, or raw stderr exc
 ## First-Run / Discovery
 
 9router configuration is manually supplied host-local state. Unlike generic service
-discovery, the workflow cannot safely infer `base_url`, `log_dir`, `stderr_log`,
-`restart_command`, or `log_bloat_threshold_gb`.
+discovery, the workflow cannot safely infer `base_url`, `log_dir`, `stderr_log`, or
+`log_bloat_threshold_gb`.
 
 Allowed first-run behavior:
 


### PR DESCRIPTION
## Summary

Follow-up PR from bot review sweep on #126.

- `restart_command` was listed as a required schema key in `workflows/9router-health/AGENT.md`, but automatic restarts are explicitly disabled by the Remediation Posture
- A host that omitted this unused key would silently enter report-only mode (no alerts), including killing P1 process-down alerting
- Fix: moved to a new `### Optional schema` section with a clear note that it's reserved for future restart policy

## What was triaged

| Bot | Comment | Disposition |
|-----|---------|-------------|
| `chatgpt-codex-connector[bot]` | README missing 9router-health workflow entry | **Incorrect** — already present at README.md line 155 |
| `cursor[bot]` | Circuit breakers declared but never defined | **Incorrect** — `## Circuit Breakers` section fully defined (added in c1fb507) |
| `cursor[bot]` | No log rotation for health check logs | **Incorrect** — `### Log Retention` with 30-day `find … -delete` added in c1fb507 |
| `cursor[bot]` | Stale-config discovery may overwrite manual config | **Incorrect** — "Do not invent or overwrite" guard added in c1fb507 |
| `cursor[bot]` | `restart_command` required but unused, suppresses all alerts | **Fixed** in this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)